### PR TITLE
Feat/use controllable state

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -19,7 +19,7 @@ typed reusable React hooks, small utility components, and clear client/server bo
 - [x] `useLocalStorage`
 - [x] `useSessionStorage`
 - [x] `usePrevious`
-- [ ] `useControllableState`
+- [x] `useControllableState`
 - [ ] `useDisclosure`
 - [ ] `useMediaQuery`
 - [ ] `useWindowSize`

--- a/docs/components/demos/use-controllable-state-demo.tsx
+++ b/docs/components/demos/use-controllable-state-demo.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState } from "react";
+import { useControllableState } from "react-rsc-kit/client";
+
+import styles from "./demo-tokens.module.css";
+
+const PLAN_OPTIONS = ["starter", "team", "enterprise"];
+
+export function UseControllableStateDemo() {
+  const [parentEnabled, setParentEnabled] = useState(true);
+  const [enabled, setEnabled, enabledMeta] = useControllableState<boolean>({
+    value: parentEnabled,
+    onChange: (nextValue) => setParentEnabled(nextValue),
+    name: "NotificationToggle.enabled",
+  });
+  const [plan, setPlan, planMeta] = useControllableState<string>({
+    defaultValue: "team",
+    name: "PlanSelect.value",
+  });
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.between}>
+        <div>
+          <p className={styles.eyebrow}>Design system state</p>
+          <h4 className={styles.title}>Controlled and uncontrolled controls</h4>
+        </div>
+        <span className={`${styles.pill} ${enabled ? styles.pillSuccess : styles.pillNeutral}`}>
+          {enabled ? "Notifications On" : "Notifications Off"}
+        </span>
+      </div>
+
+      <div className={styles.surface}>
+        <div className={styles.between}>
+          <div>
+            <p className={styles.eyebrow}>Controlled toggle</p>
+            <h4 className={styles.title}>Parent value: {String(parentEnabled)}</h4>
+            <p className={styles.meta}>
+              Hook mode: {enabledMeta.isControlled ? "Controlled" : "Uncontrolled"}
+            </p>
+          </div>
+
+          <button
+            type="button"
+            className={`${styles.button} ${enabled ? styles.buttonActive : ""}`}
+            aria-pressed={enabled ?? false}
+            onClick={() => setEnabled((currentValue) => !currentValue)}
+          >
+            Toggle
+          </button>
+        </div>
+      </div>
+
+      <div className={styles.surface}>
+        <div className={styles.between}>
+          <div>
+            <p className={styles.eyebrow}>Uncontrolled select</p>
+            <h4 className={styles.title}>Plan: {plan}</h4>
+            <p className={styles.meta}>
+              Hook mode: {planMeta.isControlled ? "Controlled" : "Uncontrolled"}
+            </p>
+          </div>
+
+          <select
+            value={plan ?? ""}
+            onChange={(event) => setPlan(event.target.value)}
+            style={{
+              borderRadius: 999,
+              border: "1px solid var(--uk-demo-border-strong)",
+              background: "var(--uk-demo-button-bg)",
+              color: "var(--uk-demo-text)",
+              font: "inherit",
+              fontWeight: 600,
+              padding: "0.6rem 0.9rem",
+              textTransform: "capitalize",
+            }}
+          >
+            {PLAN_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/content/hooks/_meta.json
+++ b/docs/content/hooks/_meta.json
@@ -6,6 +6,7 @@
     "subcategory": "UI"
   },
   "useToggle": "useToggle",
+  "useControllableState": "useControllableState",
   "useTimeout": "useTimeout",
   "useGeolocation": "useGeolocation",
   "useDebounce": "useDebounce",

--- a/docs/content/hooks/useControllableState.mdx
+++ b/docs/content/hooks/useControllableState.mdx
@@ -1,0 +1,177 @@
+import { DemoFrame } from "../../components/demo-frame";
+import { UseControllableStateDemo } from "../../components/demos/use-controllable-state-demo";
+
+# useControllableState
+
+`useControllableState` lets design-system components support controlled and uncontrolled state with one consistent setter contract.
+
+<DemoFrame
+  title="Controllable component state"
+  description="This demo shows one controlled value owned by the parent and one uncontrolled value owned by the hook."
+>
+  <UseControllableStateDemo />
+</DemoFrame>
+
+## Import
+
+```tsx
+import { useControllableState } from "react-rsc-kit/client";
+```
+
+## Signature
+
+```ts
+const [value, setValue, meta] = useControllableState<T>({
+  value,
+  defaultValue,
+  onChange,
+  name,
+  shouldUpdate,
+});
+```
+
+## Parameters
+
+| Name           | Type                                          | Default     | Description                                                                  |
+| -------------- | --------------------------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `value`        | `T`                                           | `undefined` | Controlled value. The hook is controlled when this is not `undefined`.       |
+| `defaultValue` | `T \| () => T`                                | `undefined` | Initial uncontrolled value. Later changes to `defaultValue` are ignored.     |
+| `onChange`     | `(nextValue: T, previousValue: T) => void`    | `undefined` | Called when an accepted value change is requested.                           |
+| `name`         | `string`                                      | `undefined` | Component or state name included in development warnings.                    |
+| `shouldUpdate` | `(nextValue: T, previousValue: T) => boolean` | `Object.is` | Custom predicate. Return `true` when the requested update should be applied. |
+
+## Returns
+
+| Item       | Description                                                                 |
+| ---------- | --------------------------------------------------------------------------- |
+| `value`    | Controlled `value` when controlled, otherwise internal uncontrolled state.  |
+| `setValue` | React-style setter supporting direct values and functional updates.         |
+| `meta`     | Object with `isControlled`, useful for diagnostics and component internals. |
+
+## Controlled Toggle
+
+```tsx
+"use client";
+
+import { useControllableState } from "react-rsc-kit/client";
+
+interface ControlledToggleProps {
+  pressed: boolean;
+  onPressedChange: (nextPressed: boolean, previousPressed: boolean) => void;
+}
+
+export function ControlledToggle({ pressed, onPressedChange }: ControlledToggleProps) {
+  const [isPressed, setPressed] = useControllableState<boolean>({
+    value: pressed,
+    onChange: onPressedChange,
+    name: "Toggle.pressed",
+  });
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isPressed ?? false}
+      onClick={() => setPressed((currentValue) => !currentValue)}
+    >
+      {isPressed ? "On" : "Off"}
+    </button>
+  );
+}
+```
+
+## Uncontrolled Toggle
+
+```tsx
+"use client";
+
+import { useControllableState } from "react-rsc-kit/client";
+
+export function UncontrolledToggle() {
+  const [isPressed, setPressed] = useControllableState<boolean>({
+    defaultValue: false,
+    name: "Toggle.pressed",
+  });
+
+  return (
+    <button
+      type="button"
+      aria-pressed={isPressed ?? false}
+      onClick={() => setPressed((currentValue) => !currentValue)}
+    >
+      {isPressed ? "On" : "Off"}
+    </button>
+  );
+}
+```
+
+## Controlled Dialog
+
+```tsx
+"use client";
+
+import { useControllableState } from "react-rsc-kit/client";
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (nextOpen: boolean, previousOpen: boolean) => void;
+}
+
+export function Dialog({ open, onOpenChange }: DialogProps) {
+  const [isOpen, setOpen] = useControllableState<boolean>({
+    value: open,
+    onChange: onOpenChange,
+    name: "Dialog.open",
+  });
+
+  return (
+    <section hidden={!isOpen}>
+      <button type="button" onClick={() => setOpen(false)}>
+        Close
+      </button>
+    </section>
+  );
+}
+```
+
+## Select Value
+
+```tsx
+"use client";
+
+import { useControllableState } from "react-rsc-kit/client";
+
+interface SelectProps {
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (nextValue: string, previousValue: string) => void;
+}
+
+export function Select({ value, defaultValue, onValueChange }: SelectProps) {
+  const [selectedValue, setSelectedValue] = useControllableState<string>({
+    value,
+    defaultValue,
+    onChange: onValueChange,
+    name: "Select.value",
+  });
+
+  return (
+    <select value={selectedValue ?? ""} onChange={(event) => setSelectedValue(event.target.value)}>
+      <option value="" disabled>
+        Choose a value
+      </option>
+      <option value="react">React</option>
+      <option value="typescript">TypeScript</option>
+      <option value="design-system">Design System</option>
+    </select>
+  );
+}
+```
+
+## Notes
+
+- The hook is controlled when `value !== undefined`; `undefined` intentionally means "uncontrolled".
+- `defaultValue` is read only for uncontrolled initialization.
+- `setValue` supports functional updates and calls the latest `onChange` callback.
+- `shouldUpdate` defaults to skipping updates where `Object.is(nextValue, previousValue)` is true.
+- Development warnings report controlled/uncontrolled mode switches and mixed `value` plus `defaultValue` usage.
+- Avoid switching a component between controlled and uncontrolled modes after mount.

--- a/docs/public/sw.js
+++ b/docs/public/sw.js
@@ -1,0 +1,8 @@
+// No-op service worker endpoint for stale registrations and browser probes.
+self.addEventListener("install", () => {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.registration.unregister());
+});

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -19,7 +19,7 @@
   --nextra-primary-saturation: 11%;
   --nextra-primary-lightness: 42%;
   --nextra-bg: 247, 246, 243;
-  --nextra-content-width: 76rem;
+  --nextra-content-width: 100rem;
 }
 
 .dark {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-rsc-kit",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "React hooks and utility components with RSC-safe server/client entrypoints.",
   "author": "react-rsc-kit contributors",
   "license": "MIT",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ export * from "./useArray";
 export * from "./useAsync";
 export * from "./useAsyncFnc";
 export * from "./useClickOutside";
+export * from "./useControllableState";
 export * from "./useCopyToClipboard";
 export * from "./useDebounce";
 export * from "./useEventListener";

--- a/src/hooks/useControllableState/index.ts
+++ b/src/hooks/useControllableState/index.ts
@@ -1,0 +1,1 @@
+export * from "./useControllableState";

--- a/src/hooks/useControllableState/useControllableState.ts
+++ b/src/hooks/useControllableState/useControllableState.ts
@@ -1,0 +1,199 @@
+import {
+  Dispatch,
+  MutableRefObject,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+/**
+ * Options for `useControllableState`.
+ */
+export interface UseControllableStateOptions<T> {
+  /**
+   * Controlled value.
+   * If this is not `undefined`, the hook is controlled.
+   */
+  value?: T;
+
+  /**
+   * Initial value for uncontrolled mode.
+   * Supports either a direct value or a lazy initializer.
+   */
+  defaultValue?: T | (() => T);
+
+  /**
+   * Called whenever a value change is requested and accepted.
+   */
+  onChange?: (nextValue: T, previousValue: T) => void;
+
+  /**
+   * Optional component or state name used in development warnings.
+   */
+  name?: string;
+
+  /**
+   * Optional update predicate.
+   * Return `true` when the update should be applied.
+   * Defaults to applying updates only when `Object.is` reports a difference.
+   */
+  shouldUpdate?: (nextValue: T, previousValue: T) => boolean;
+}
+
+/**
+ * Metadata returned by `useControllableState`.
+ */
+export interface UseControllableStateMeta {
+  /**
+   * Whether the hook is currently using the controlled `value`.
+   */
+  isControlled: boolean;
+}
+
+/**
+ * Return tuple for `useControllableState`.
+ */
+export type UseControllableStateReturn<T> = [
+  value: T | undefined,
+  setValue: Dispatch<SetStateAction<T | undefined>>,
+  meta: UseControllableStateMeta,
+];
+
+function resolveDefaultValue<T>(defaultValue: T | (() => T) | undefined): T | undefined {
+  return typeof defaultValue === "function" ? (defaultValue as () => T)() : defaultValue;
+}
+
+function resolveNextValue<T>(
+  nextValue: SetStateAction<T | undefined>,
+  previousValue: T | undefined,
+): T | undefined {
+  return typeof nextValue === "function"
+    ? (nextValue as (previousValue: T | undefined) => T | undefined)(previousValue)
+    : nextValue;
+}
+
+function shouldApplyUpdate<T>(
+  nextValue: T | undefined,
+  previousValue: T | undefined,
+  shouldUpdate: UseControllableStateOptions<T>["shouldUpdate"] | undefined,
+): boolean {
+  if (shouldUpdate) {
+    return shouldUpdate(nextValue as T, previousValue as T);
+  }
+
+  return !Object.is(nextValue, previousValue);
+}
+
+function useLatestRef<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+function isDevelopmentEnvironment(): boolean {
+  return typeof process !== "undefined" && process.env.NODE_ENV !== "production";
+}
+
+function getWarningName(name: string | undefined): string {
+  return name ? ` for "${name}"` : "";
+}
+
+function getModeLabel(isControlled: boolean): "controlled" | "uncontrolled" {
+  return isControlled ? "controlled" : "uncontrolled";
+}
+
+/**
+ * Manage state that can be either controlled by a parent component or owned internally.
+ *
+ * Controlled mode is selected when `value !== undefined`. In controlled mode the returned value
+ * always mirrors `value`, and the setter only requests changes through `onChange`. In uncontrolled
+ * mode the hook initializes internal state from `defaultValue`, updates that internal state from
+ * the setter, and still calls `onChange` for accepted changes.
+ */
+export function useControllableState<T>({
+  value,
+  defaultValue,
+  onChange,
+  name,
+  shouldUpdate,
+}: UseControllableStateOptions<T> = {}): UseControllableStateReturn<T> {
+  const isControlled = value !== undefined;
+  const hasDefaultValue = defaultValue !== undefined;
+
+  const [uncontrolledValue, setUncontrolledValue] = useState<T | undefined>(() =>
+    isControlled ? undefined : resolveDefaultValue(defaultValue),
+  );
+
+  const currentValue = isControlled ? value : uncontrolledValue;
+  const currentValueRef = useLatestRef(currentValue);
+  const isControlledRef = useLatestRef(isControlled);
+  const onChangeRef = useLatestRef(onChange);
+  const shouldUpdateRef = useLatestRef(shouldUpdate);
+
+  const initialIsControlledRef = useRef(isControlled);
+  const didWarnModeChangeRef = useRef(false);
+  const didWarnMixedValueRef = useRef(false);
+
+  useEffect(() => {
+    if (!isDevelopmentEnvironment() || didWarnModeChangeRef.current) {
+      return;
+    }
+
+    if (initialIsControlledRef.current !== isControlled) {
+      const previousMode = getModeLabel(initialIsControlledRef.current);
+      const nextMode = getModeLabel(isControlled);
+
+      console.warn(
+        `useControllableState${getWarningName(
+          name,
+        )} changed from ${previousMode} to ${nextMode}. Components should not switch between controlled and uncontrolled state after mount.`,
+      );
+
+      didWarnModeChangeRef.current = true;
+    }
+  }, [isControlled, name]);
+
+  useEffect(() => {
+    if (!isDevelopmentEnvironment() || didWarnMixedValueRef.current) {
+      return;
+    }
+
+    if (isControlled && hasDefaultValue) {
+      console.warn(
+        `useControllableState${getWarningName(
+          name,
+        )} received both value and defaultValue. Choose either controlled or uncontrolled state for the component lifetime.`,
+      );
+
+      didWarnMixedValueRef.current = true;
+    }
+  }, [hasDefaultValue, isControlled, name]);
+
+  const setValue = useCallback<Dispatch<SetStateAction<T | undefined>>>((nextValueOrUpdater) => {
+    const previousValue = currentValueRef.current;
+    const nextValue = resolveNextValue(nextValueOrUpdater, previousValue);
+
+    if (!shouldApplyUpdate(nextValue, previousValue, shouldUpdateRef.current)) {
+      return;
+    }
+
+    if (!isControlledRef.current) {
+      currentValueRef.current = nextValue;
+      setUncontrolledValue(nextValue);
+    }
+
+    onChangeRef.current?.(nextValue as T, previousValue as T);
+  }, []);
+
+  const meta = useMemo<UseControllableStateMeta>(
+    () => ({
+      isControlled,
+    }),
+    [isControlled],
+  );
+
+  return [currentValue, setValue, meta];
+}

--- a/tests/use-controllable-state.test.tsx
+++ b/tests/use-controllable-state.test.tsx
@@ -1,0 +1,400 @@
+import { act, renderHook } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useControllableState } from "../src/client/hooks";
+
+describe("useControllableState", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("initializes uncontrolled state from a direct defaultValue", () => {
+    const { result } = renderHook(() =>
+      useControllableState<string>({
+        defaultValue: "initial",
+      }),
+    );
+
+    expect(result.current[0]).toBe("initial");
+    expect(result.current[2].isControlled).toBe(false);
+  });
+
+  it("supports lazy uncontrolled initialization", () => {
+    const initializer = vi.fn(() => "lazy");
+    const { result, rerender } = renderHook(() =>
+      useControllableState<string>({
+        defaultValue: initializer,
+      }),
+    );
+
+    rerender();
+
+    expect(result.current[0]).toBe("lazy");
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats undefined value as uncontrolled", () => {
+    const { result } = renderHook(() =>
+      useControllableState<string>({
+        value: undefined,
+        defaultValue: "fallback",
+      }),
+    );
+
+    expect(result.current[0]).toBe("fallback");
+    expect(result.current[2].isControlled).toBe(false);
+  });
+
+  it("does not re-read defaultValue after uncontrolled initialization", () => {
+    const { result, rerender } = renderHook(
+      ({ defaultValue }: { defaultValue: string }) =>
+        useControllableState<string>({
+          defaultValue,
+        }),
+      {
+        initialProps: {
+          defaultValue: "first",
+        },
+      },
+    );
+
+    rerender({
+      defaultValue: "second",
+    });
+
+    expect(result.current[0]).toBe("first");
+  });
+
+  it("updates uncontrolled state and calls onChange", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState<number>({
+        defaultValue: 1,
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current[1](2);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(2, 1);
+  });
+
+  it("uses the controlled value as the source of truth", () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) =>
+        useControllableState<string>({
+          value,
+        }),
+      {
+        initialProps: {
+          value: "first",
+        },
+      },
+    );
+
+    expect(result.current[0]).toBe("first");
+    expect(result.current[2].isControlled).toBe(true);
+
+    rerender({
+      value: "second",
+    });
+
+    expect(result.current[0]).toBe("second");
+  });
+
+  it("calls onChange without updating internal state in controlled mode", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState<string>({
+        value: "current",
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current[1]("requested");
+    });
+
+    expect(result.current[0]).toBe("current");
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("requested", "current");
+  });
+
+  it("supports functional updates in uncontrolled mode", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState<number>({
+        defaultValue: 1,
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current[1]((currentValue) => (currentValue ?? 0) + 1);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(onChange).toHaveBeenCalledWith(2, 1);
+  });
+
+  it("composes consecutive uncontrolled functional updates", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState<number>({
+        defaultValue: 0,
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current[1]((currentValue) => (currentValue ?? 0) + 1);
+      result.current[1]((currentValue) => (currentValue ?? 0) + 1);
+    });
+
+    expect(result.current[0]).toBe(2);
+    expect(onChange).toHaveBeenNthCalledWith(1, 1, 0);
+    expect(onChange).toHaveBeenNthCalledWith(2, 2, 1);
+  });
+
+  it("supports functional updates in controlled mode", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useControllableState<number>({
+        value: 10,
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current[1]((currentValue) => (currentValue ?? 0) + 5);
+    });
+
+    expect(result.current[0]).toBe(10);
+    expect(onChange).toHaveBeenCalledWith(15, 10);
+  });
+
+  it("does not call onChange when the requested value is unchanged", () => {
+    const uncontrolledOnChange = vi.fn();
+    const controlledOnChange = vi.fn();
+    const { result: uncontrolledResult } = renderHook(() =>
+      useControllableState<string>({
+        defaultValue: "same",
+        onChange: uncontrolledOnChange,
+      }),
+    );
+    const { result: controlledResult } = renderHook(() =>
+      useControllableState<string>({
+        value: "same",
+        onChange: controlledOnChange,
+      }),
+    );
+
+    act(() => {
+      uncontrolledResult.current[1]("same");
+      controlledResult.current[1]("same");
+    });
+
+    expect(uncontrolledOnChange).not.toHaveBeenCalled();
+    expect(controlledOnChange).not.toHaveBeenCalled();
+  });
+
+  it("uses a custom shouldUpdate predicate", () => {
+    interface Item {
+      id: number;
+      label: string;
+    }
+
+    const onChange = vi.fn();
+    const shouldUpdate = vi.fn((nextValue: Item, previousValue: Item) => {
+      return nextValue.id !== previousValue.id;
+    });
+    const { result } = renderHook(() =>
+      useControllableState<Item>({
+        defaultValue: {
+          id: 1,
+          label: "Initial",
+        },
+        onChange,
+        shouldUpdate,
+      }),
+    );
+
+    act(() => {
+      result.current[1]({
+        id: 1,
+        label: "Ignored",
+      });
+    });
+
+    expect(result.current[0]).toEqual({
+      id: 1,
+      label: "Initial",
+    });
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current[1]({
+        id: 2,
+        label: "Accepted",
+      });
+    });
+
+    expect(result.current[0]).toEqual({
+      id: 2,
+      label: "Accepted",
+    });
+    expect(shouldUpdate).toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the latest onChange callback", () => {
+    const firstOnChange = vi.fn();
+    const secondOnChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onChange }: { onChange: (nextValue: string, previousValue: string) => void }) =>
+        useControllableState<string>({
+          defaultValue: "initial",
+          onChange,
+        }),
+      {
+        initialProps: {
+          onChange: firstOnChange,
+        },
+      },
+    );
+
+    rerender({
+      onChange: secondOnChange,
+    });
+
+    act(() => {
+      result.current[1]("next");
+    });
+
+    expect(firstOnChange).not.toHaveBeenCalled();
+    expect(secondOnChange).toHaveBeenCalledWith("next", "initial");
+  });
+
+  it("uses the latest shouldUpdate predicate", () => {
+    const firstShouldUpdate = vi.fn(() => false);
+    const secondShouldUpdate = vi.fn(() => true);
+    const { result, rerender } = renderHook(
+      ({ shouldUpdate }: { shouldUpdate: (nextValue: number, previousValue: number) => boolean }) =>
+        useControllableState<number>({
+          defaultValue: 0,
+          shouldUpdate,
+        }),
+      {
+        initialProps: {
+          shouldUpdate: firstShouldUpdate,
+        },
+      },
+    );
+
+    rerender({
+      shouldUpdate: secondShouldUpdate,
+    });
+
+    act(() => {
+      result.current[1](1);
+    });
+
+    expect(result.current[0]).toBe(1);
+    expect(firstShouldUpdate).not.toHaveBeenCalled();
+    expect(secondShouldUpdate).toHaveBeenCalledWith(1, 0);
+  });
+
+  it("warns when switching between uncontrolled and controlled modes", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const initialProps: { value: string | undefined } = {
+      value: undefined,
+    };
+    const { rerender } = renderHook(
+      ({ value }: { value: string | undefined }) =>
+        useControllableState<string>({
+          value,
+          name: "Tabs.value",
+        }),
+      {
+        initialProps,
+      },
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+
+    rerender({
+      value: "settings",
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Tabs.value"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("uncontrolled to controlled"));
+
+    rerender({
+      value: "billing",
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns when both value and defaultValue are provided", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { rerender } = renderHook(() =>
+      useControllableState<string>({
+        value: "controlled",
+        defaultValue: "uncontrolled",
+        name: "Select.value",
+      }),
+    );
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("Select.value"));
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("both value and defaultValue"));
+
+    rerender();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warn in production", () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    process.env.NODE_ENV = "production";
+
+    try {
+      renderHook(() =>
+        useControllableState<string>({
+          value: "controlled",
+          defaultValue: "uncontrolled",
+          name: "Select.value",
+        }),
+      );
+
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    }
+  });
+
+  it("renders safely on the server", () => {
+    function ServerRenderedValue() {
+      const [value] = useControllableState<string>({
+        defaultValue: "server",
+      });
+
+      return <span>{value}</span>;
+    }
+
+    expect(renderToString(<ServerRenderedValue />)).toContain("<span>server</span>");
+  });
+});


### PR DESCRIPTION
## Summary

## What does this PR change?

Adds a reusable `useControllableState` hook to support both controlled and uncontrolled state patterns in React components.

It handles:

* `value` and `defaultValue`
* `onChange` callbacks
* functional updates
* custom update checks
* development warnings
* TypeScript-safe usage

## Why is it needed?

This avoids duplicating controlled/uncontrolled state logic across reusable components like `Dialog`, `Select`, `Tabs`, `Toggle`, and form inputs.

It improves consistency, maintainability, and reliability across the component library.


## Checklist

- [x] Tests added/updated
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] `npm run build` passes
- [x] Docs/README updated if API changed
