### PR TITLE
feat: add useDisclosure hook

### DIFF
--- a/docs/components/demos/use-disclosure-demo.tsx
+++ b/docs/components/demos/use-disclosure-demo.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState } from "react";
+import { useDisclosure } from "react-rsc-kit/client";
+
+import styles from "./demo-tokens.module.css";
+
+export function UseDisclosureDemo() {
+  const detailsDisclosure = useDisclosure({
+    defaultOpen: true,
+  });
+  const [panelOpen, setPanelOpen] = useState(false);
+  const panelDisclosure = useDisclosure({
+    open: panelOpen,
+    onChange: setPanelOpen,
+  });
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.between}>
+        <div>
+          <p className={styles.eyebrow}>Disclosure state</p>
+          <h4 className={styles.title}>Account controls</h4>
+        </div>
+        <span
+          className={`${styles.pill} ${
+            panelDisclosure.isOpen ? styles.pillSuccess : styles.pillNeutral
+          }`}
+        >
+          {panelDisclosure.isOpen ? "Panel Open" : "Panel Closed"}
+        </span>
+      </div>
+
+      <div className={styles.surface}>
+        <div className={styles.between}>
+          <div>
+            <p className={styles.eyebrow}>Uncontrolled section</p>
+            <h4 className={styles.title}>Billing details</h4>
+          </div>
+          <button
+            type="button"
+            className={`${styles.button} ${detailsDisclosure.isOpen ? styles.buttonActive : ""}`}
+            aria-expanded={detailsDisclosure.isOpen}
+            onClick={detailsDisclosure.toggle}
+          >
+            {detailsDisclosure.isOpen ? "Hide" : "Show"}
+          </button>
+        </div>
+
+        {detailsDisclosure.isOpen ? (
+          <p className={styles.muted}>Annual plan, card ending in 4242, renewal on May 18.</p>
+        ) : null}
+      </div>
+
+      <div className={styles.surface}>
+        <div className={styles.between}>
+          <div>
+            <p className={styles.eyebrow}>Controlled panel</p>
+            <h4 className={styles.title}>Security review</h4>
+            <p className={styles.meta}>Parent state: {String(panelOpen)}</p>
+          </div>
+          <div className={styles.row}>
+            <button
+              type="button"
+              className={`${styles.button} ${panelDisclosure.isOpen ? styles.buttonActive : ""}`}
+              aria-expanded={panelDisclosure.isOpen}
+              onClick={panelDisclosure.open}
+            >
+              Open
+            </button>
+            <button type="button" className={styles.button} onClick={panelDisclosure.close}>
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/content/hooks/_meta.json
+++ b/docs/content/hooks/_meta.json
@@ -7,6 +7,7 @@
   },
   "useToggle": "useToggle",
   "useControllableState": "useControllableState",
+  "useDisclosure": "useDisclosure",
   "useTimeout": "useTimeout",
   "useGeolocation": "useGeolocation",
   "useDebounce": "useDebounce",

--- a/docs/content/hooks/useDisclosure.mdx
+++ b/docs/content/hooks/useDisclosure.mdx
@@ -1,0 +1,109 @@
+import { DemoFrame } from "../../components/demo-frame";
+import { UseDisclosureDemo } from "../../components/demos/use-disclosure-demo";
+
+# useDisclosure
+
+`useDisclosure` manages boolean open state for UI such as dialogs, popovers, accordions, and details panels.
+
+<DemoFrame
+  title="Disclosure controls"
+  description="This demo shows one uncontrolled disclosure and one controlled panel using the same action API."
+>
+  <UseDisclosureDemo />
+</DemoFrame>
+
+## Import
+
+```tsx
+import { useDisclosure } from "react-rsc-kit/client";
+```
+
+## Signature
+
+```ts
+const { isOpen, open, close, toggle, setOpen } = useDisclosure({
+  open,
+  defaultOpen,
+  onOpen,
+  onClose,
+  onChange,
+});
+```
+
+## Parameters
+
+| Name          | Type                      | Default     | Description                                                                  |
+| ------------- | ------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `open`        | `boolean`                 | `undefined` | Controlled open state. The hook is controlled when this is not `undefined`.  |
+| `defaultOpen` | `boolean`                 | `false`     | Initial uncontrolled open state. Later changes to `defaultOpen` are ignored. |
+| `onOpen`      | `() => void`              | `undefined` | Called when the disclosure transitions from closed to open.                  |
+| `onClose`     | `() => void`              | `undefined` | Called when the disclosure transitions from open to closed.                  |
+| `onChange`    | `(open: boolean) => void` | `undefined` | Called when the disclosure open state changes.                               |
+
+## Returns
+
+| Key       | Description                                                  |
+| --------- | ------------------------------------------------------------ |
+| `isOpen`  | Controlled `open` when controlled, otherwise internal state. |
+| `open`    | Opens the disclosure.                                        |
+| `close`   | Closes the disclosure.                                       |
+| `toggle`  | Flips the disclosure state.                                  |
+| `setOpen` | Sets the disclosure state to a specific boolean value.       |
+
+## Controlled Dialog
+
+```tsx
+"use client";
+
+import { useDisclosure } from "react-rsc-kit/client";
+
+interface DialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function Dialog({ open, onOpenChange }: DialogProps) {
+  const disclosure = useDisclosure({
+    open,
+    onChange: onOpenChange,
+  });
+
+  return (
+    <section hidden={!disclosure.isOpen}>
+      <button type="button" onClick={disclosure.close}>
+        Close
+      </button>
+    </section>
+  );
+}
+```
+
+## Uncontrolled Details
+
+```tsx
+"use client";
+
+import { useDisclosure } from "react-rsc-kit/client";
+
+export function DetailsPanel() {
+  const disclosure = useDisclosure({
+    defaultOpen: true,
+  });
+
+  return (
+    <section>
+      <button type="button" aria-expanded={disclosure.isOpen} onClick={disclosure.toggle}>
+        {disclosure.isOpen ? "Hide details" : "Show details"}
+      </button>
+      {disclosure.isOpen ? <p>Plan details and account limits.</p> : null}
+    </section>
+  );
+}
+```
+
+## Notes
+
+- The hook is controlled when `open !== undefined`; `undefined` intentionally means "uncontrolled".
+- `defaultOpen` is read only for uncontrolled initialization.
+- `open`, `close`, `toggle`, and `setOpen` are stable callbacks.
+- `onOpen`, `onClose`, and `onChange` run only when the requested state differs from the current state.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "React hooks and utility components with RSC-safe server/client entrypoints.",
   "author": "react-rsc-kit contributors",
   "license": "MIT",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from "./useClickOutside";
 export * from "./useControllableState";
 export * from "./useCopyToClipboard";
 export * from "./useDebounce";
+export * from "./useDisclosure";
 export * from "./useEventListener";
 export * from "./useFetch";
 export * from "./useGeolocation";

--- a/src/hooks/useDisclosure/index.ts
+++ b/src/hooks/useDisclosure/index.ts
@@ -1,0 +1,1 @@
+export * from "./useDisclosure";

--- a/src/hooks/useDisclosure/useDisclosure.ts
+++ b/src/hooks/useDisclosure/useDisclosure.ts
@@ -1,5 +1,7 @@
 import { MutableRefObject, useCallback, useMemo, useRef, useState } from "react";
 
+import { useIsomorphicEffect } from "../useIsomorphicEffect";
+
 /**
  * Options for `useDisclosure`.
  */
@@ -64,7 +66,11 @@ export interface UseDisclosureReturn {
 
 function useLatestRef<T>(value: T): MutableRefObject<T> {
   const ref = useRef(value);
-  ref.current = value;
+
+  useIsomorphicEffect(() => {
+    ref.current = value;
+  }, [value]);
+
   return ref;
 }
 

--- a/src/hooks/useDisclosure/useDisclosure.ts
+++ b/src/hooks/useDisclosure/useDisclosure.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback, useRef, useState } from "react";
+import { MutableRefObject, useCallback, useMemo, useRef, useState } from "react";
 
 /**
  * Options for `useDisclosure`.
@@ -120,11 +120,14 @@ export function useDisclosure(options: UseDisclosureOptions = {}): UseDisclosure
     setOpen(!isOpenRef.current);
   }, [setOpen]);
 
-  return {
-    isOpen,
-    open,
-    close,
-    toggle,
-    setOpen,
-  };
+  return useMemo<UseDisclosureReturn>(
+    () => ({
+      isOpen,
+      open,
+      close,
+      toggle,
+      setOpen,
+    }),
+    [close, isOpen, open, setOpen, toggle],
+  );
 }

--- a/src/hooks/useDisclosure/useDisclosure.ts
+++ b/src/hooks/useDisclosure/useDisclosure.ts
@@ -93,8 +93,9 @@ export function useDisclosure(options: UseDisclosureOptions = {}): UseDisclosure
       return;
     }
 
+    isOpenRef.current = nextOpen;
+
     if (!isControlledRef.current) {
-      isOpenRef.current = nextOpen;
       setUncontrolledOpen(nextOpen);
     }
 

--- a/src/hooks/useDisclosure/useDisclosure.ts
+++ b/src/hooks/useDisclosure/useDisclosure.ts
@@ -1,0 +1,129 @@
+import { MutableRefObject, useCallback, useRef, useState } from "react";
+
+/**
+ * Options for `useDisclosure`.
+ */
+export interface UseDisclosureOptions {
+  /**
+   * Controlled open state.
+   * If this is not `undefined`, the hook is controlled.
+   */
+  open?: boolean;
+
+  /**
+   * Initial open state for uncontrolled mode.
+   * Later changes are ignored.
+   */
+  defaultOpen?: boolean;
+
+  /**
+   * Called when the disclosure transitions from closed to open.
+   */
+  onOpen?: () => void;
+
+  /**
+   * Called when the disclosure transitions from open to closed.
+   */
+  onClose?: () => void;
+
+  /**
+   * Called when the disclosure open state changes.
+   */
+  onChange?: (open: boolean) => void;
+}
+
+/**
+ * Return value for `useDisclosure`.
+ */
+export interface UseDisclosureReturn {
+  /**
+   * Current open state.
+   */
+  isOpen: boolean;
+
+  /**
+   * Opens the disclosure.
+   */
+  open: () => void;
+
+  /**
+   * Closes the disclosure.
+   */
+  close: () => void;
+
+  /**
+   * Toggles the disclosure.
+   */
+  toggle: () => void;
+
+  /**
+   * Sets the disclosure open state.
+   */
+  setOpen: (open: boolean) => void;
+}
+
+function useLatestRef<T>(value: T): MutableRefObject<T> {
+  const ref = useRef(value);
+  ref.current = value;
+  return ref;
+}
+
+/**
+ * Manage boolean disclosure state for UI that can be either controlled or uncontrolled.
+ */
+export function useDisclosure(options: UseDisclosureOptions = {}): UseDisclosureReturn {
+  const { open: controlledOpen, defaultOpen = false, onOpen, onClose, onChange } = options;
+  const isControlled = controlledOpen !== undefined;
+
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(() =>
+    isControlled ? false : defaultOpen,
+  );
+
+  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
+  const isOpenRef = useLatestRef(isOpen);
+  const isControlledRef = useLatestRef(isControlled);
+  const onOpenRef = useLatestRef(onOpen);
+  const onCloseRef = useLatestRef(onClose);
+  const onChangeRef = useLatestRef(onChange);
+
+  const setOpen = useCallback((nextOpen: boolean) => {
+    const previousOpen = isOpenRef.current;
+
+    if (Object.is(previousOpen, nextOpen)) {
+      return;
+    }
+
+    if (!isControlledRef.current) {
+      isOpenRef.current = nextOpen;
+      setUncontrolledOpen(nextOpen);
+    }
+
+    if (nextOpen) {
+      onOpenRef.current?.();
+    } else {
+      onCloseRef.current?.();
+    }
+
+    onChangeRef.current?.(nextOpen);
+  }, []);
+
+  const open = useCallback(() => {
+    setOpen(true);
+  }, [setOpen]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+  }, [setOpen]);
+
+  const toggle = useCallback(() => {
+    setOpen(!isOpenRef.current);
+  }, [setOpen]);
+
+  return {
+    isOpen,
+    open,
+    close,
+    toggle,
+    setOpen,
+  };
+}

--- a/tests/use-disclosure.ssr.test.tsx
+++ b/tests/use-disclosure.ssr.test.tsx
@@ -1,0 +1,20 @@
+// @vitest-environment node
+
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { useDisclosure } from "../src/client/hooks";
+
+describe("useDisclosure SSR", () => {
+  it("renders safely on the server", () => {
+    function ServerRenderedDisclosure() {
+      const { isOpen } = useDisclosure({
+        defaultOpen: true,
+      });
+
+      return <span>{String(isOpen)}</span>;
+    }
+
+    expect(renderToString(<ServerRenderedDisclosure />)).toContain("<span>true</span>");
+  });
+});

--- a/tests/use-disclosure.test.tsx
+++ b/tests/use-disclosure.test.tsx
@@ -218,8 +218,9 @@ describe("useDisclosure", () => {
     expect(nextOnChange).toHaveBeenCalledWith(true);
   });
 
-  it("keeps action references stable across rerenders", () => {
+  it("keeps the return object and action references stable across unchanged rerenders", () => {
     const { result, rerender } = renderHook(() => useDisclosure());
+    const firstReturn = result.current;
     const firstOpen = result.current.open;
     const firstClose = result.current.close;
     const firstToggle = result.current.toggle;
@@ -227,6 +228,7 @@ describe("useDisclosure", () => {
 
     rerender();
 
+    expect(result.current).toBe(firstReturn);
     expect(result.current.open).toBe(firstOpen);
     expect(result.current.close).toBe(firstClose);
     expect(result.current.toggle).toBe(firstToggle);

--- a/tests/use-disclosure.test.tsx
+++ b/tests/use-disclosure.test.tsx
@@ -1,0 +1,221 @@
+import { act, renderHook } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import { useDisclosure } from "../src/client/hooks";
+
+describe("useDisclosure", () => {
+  it("defaults to closed in uncontrolled mode", () => {
+    const { result } = renderHook(() => useDisclosure());
+
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it("initializes uncontrolled state from defaultOpen", () => {
+    const { result } = renderHook(() =>
+      useDisclosure({
+        defaultOpen: true,
+      }),
+    );
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("does not re-read defaultOpen after uncontrolled initialization", () => {
+    const { result, rerender } = renderHook(
+      ({ defaultOpen }: { defaultOpen: boolean }) =>
+        useDisclosure({
+          defaultOpen,
+        }),
+      {
+        initialProps: {
+          defaultOpen: true,
+        },
+      },
+    );
+
+    rerender({
+      defaultOpen: false,
+    });
+
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it("opens, closes, toggles, and notifies only on uncontrolled transitions", () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDisclosure({
+        onOpen,
+        onClose,
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
+
+    act(() => {
+      result.current.open();
+      result.current.setOpen(true);
+    });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.toggle();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it("composes consecutive uncontrolled updates before rerender", () => {
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDisclosure({
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current.toggle();
+      result.current.toggle();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onChange).toHaveBeenNthCalledWith(1, true);
+    expect(onChange).toHaveBeenNthCalledWith(2, false);
+  });
+
+  it("derives state from controlled open and ignores defaultOpen", () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const onChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ open }: { open: boolean }) =>
+        useDisclosure({
+          open,
+          defaultOpen: true,
+          onOpen,
+          onClose,
+          onChange,
+        }),
+      {
+        initialProps: {
+          open: false,
+        },
+      },
+    );
+
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
+
+    rerender({
+      open: true,
+    });
+
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.setOpen(true);
+    });
+
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it("uses the latest callbacks", () => {
+    const firstOnOpen = vi.fn();
+    const nextOnOpen = vi.fn();
+    const firstOnChange = vi.fn();
+    const nextOnChange = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ onOpen, onChange }: { onOpen: () => void; onChange: (open: boolean) => void }) =>
+        useDisclosure({
+          onOpen,
+          onChange,
+        }),
+      {
+        initialProps: {
+          onOpen: firstOnOpen,
+          onChange: firstOnChange,
+        },
+      },
+    );
+
+    rerender({
+      onOpen: nextOnOpen,
+      onChange: nextOnChange,
+    });
+
+    act(() => {
+      result.current.open();
+    });
+
+    expect(firstOnOpen).not.toHaveBeenCalled();
+    expect(firstOnChange).not.toHaveBeenCalled();
+    expect(nextOnOpen).toHaveBeenCalledTimes(1);
+    expect(nextOnChange).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps action references stable across rerenders", () => {
+    const { result, rerender } = renderHook(() => useDisclosure());
+    const firstOpen = result.current.open;
+    const firstClose = result.current.close;
+    const firstToggle = result.current.toggle;
+    const firstSetOpen = result.current.setOpen;
+
+    rerender();
+
+    expect(result.current.open).toBe(firstOpen);
+    expect(result.current.close).toBe(firstClose);
+    expect(result.current.toggle).toBe(firstToggle);
+    expect(result.current.setOpen).toBe(firstSetOpen);
+  });
+
+  it("renders safely on the server", () => {
+    function ServerRenderedDisclosure() {
+      const { isOpen } = useDisclosure({
+        defaultOpen: true,
+      });
+
+      return <span>{String(isOpen)}</span>;
+    }
+
+    expect(renderToString(<ServerRenderedDisclosure />)).toContain("<span>true</span>");
+  });
+});

--- a/tests/use-disclosure.test.tsx
+++ b/tests/use-disclosure.test.tsx
@@ -158,6 +158,32 @@ describe("useDisclosure", () => {
     expect(onChange).toHaveBeenLastCalledWith(false);
   });
 
+  it("tracks pending controlled transitions across consecutive calls before rerender", () => {
+    const onOpen = vi.fn();
+    const onClose = vi.fn();
+    const onChange = vi.fn();
+    const { result } = renderHook(() =>
+      useDisclosure({
+        open: false,
+        onOpen,
+        onClose,
+        onChange,
+      }),
+    );
+
+    act(() => {
+      result.current.setOpen(true);
+      result.current.setOpen(true);
+      result.current.toggle();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenNthCalledWith(1, true);
+    expect(onChange).toHaveBeenNthCalledWith(2, false);
+  });
+
   it("uses the latest callbacks", () => {
     const firstOnOpen = vi.fn();
     const nextOnOpen = vi.fn();

--- a/tests/use-disclosure.test.tsx
+++ b/tests/use-disclosure.test.tsx
@@ -1,5 +1,4 @@
 import { act, renderHook } from "@testing-library/react";
-import { renderToString } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import { useDisclosure } from "../src/client/hooks";
@@ -233,17 +232,5 @@ describe("useDisclosure", () => {
     expect(result.current.close).toBe(firstClose);
     expect(result.current.toggle).toBe(firstToggle);
     expect(result.current.setOpen).toBe(firstSetOpen);
-  });
-
-  it("renders safely on the server", () => {
-    function ServerRenderedDisclosure() {
-      const { isOpen } = useDisclosure({
-        defaultOpen: true,
-      });
-
-      return <span>{String(isOpen)}</span>;
-    }
-
-    expect(renderToString(<ServerRenderedDisclosure />)).toContain("<span>true</span>");
   });
 });


### PR DESCRIPTION
## Summary

## What does this PR change?

- Adds a new `useDisclosure` hook with controlled and uncontrolled usage support.
- Exports `UseDisclosureOptions` and `UseDisclosureReturn` types.
- Adds stable `open`, `close`, `toggle`, and `setOpen` callbacks.
- Ensures `onOpen`, `onClose`, and `onChange` only fire on actual state transitions.
- Adds Vitest coverage for uncontrolled behavior, controlled behavior, callback behavior, stable references, and SSR safety.
- Adds a docs page and live docs demo for `useDisclosure`.
- Updates hook and docs barrel/meta entries.

## Why is it needed?

`useDisclosure` provides a focused, production-ready primitive for common open/closed UI state such as dialogs, popovers, accordions, details panels, and drawers.

It avoids repeating custom boolean state logic across components while supporting design-system needs like controlled state, uncontrolled defaults, stable action callbacks, transition callbacks, SSR safety, and TypeScript-first exports.


## Checklist

- [x] Tests added/updated
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] `npm run build` passes
- [x] Docs/README updated if API changed
