### PR TITLE
Feat/use media query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -7,12 +7,12 @@ typed reusable React hooks, small utility components, and clear client/server bo
 
 ## Phase 1: Foundation
 
-- [ ] Rework `useFetch` into a production-safe primitive with abort support, configurable parsing, cache control, and better typing.
-- [ ] Normalize naming and API consistency across hooks:
+- [x] Rework `useFetch` into a production-safe primitive with abort support, configurable parsing, cache control, and better typing.
+- [x] Normalize naming and API consistency across hooks:
       `useAsyncFnc` -> `useAsyncFn`, `immidate` -> `immediate`, and align `useGetScrollPosition` naming.
-- [ ] Review hooks that mutate inputs and decide whether they belong as React hooks or plain utilities, especially `useArray`.
-- [ ] Expand test coverage across the existing public API before adding too many new exports.
-- [ ] Tighten docs for client-only vs server-safe imports with examples for Next.js App Router and standard React apps.
+- [x] Review hooks that mutate inputs and decide whether they belong as React hooks or plain utilities, especially `useArray`.
+- [x] Expand test coverage across the existing public API before adding too many new exports.
+- [x] Tighten docs for client-only vs server-safe imports with examples for Next.js App Router and standard React apps.
 
 ## Phase 2: High-Value Hook Additions
 
@@ -20,8 +20,8 @@ typed reusable React hooks, small utility components, and clear client/server bo
 - [x] `useSessionStorage`
 - [x] `usePrevious`
 - [x] `useControllableState`
-- [ ] `useDisclosure`
-- [ ] `useMediaQuery`
+- [x] `useDisclosure`
+- [x] `useMediaQuery`
 - [ ] `useWindowSize`
 - [ ] `useResizeObserver` or `useElementSize`
 - [ ] `useLockBodyScroll`

--- a/docs/components/demos/use-media-query-demo.tsx
+++ b/docs/components/demos/use-media-query-demo.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import { useBreakpoint, useMediaQueries, useMediaQuery } from "react-rsc-kit/client";
+
+import styles from "./demo-tokens.module.css";
+
+export function UseMediaQueryDemo() {
+  const desktop = useMediaQuery("(min-width: 1024px)", {
+    defaultValue: false,
+    ssrValue: false,
+  });
+  const screens = useMediaQueries({
+    mobile: "(max-width: 767px)",
+    tablet: "(min-width: 768px) and (max-width: 1023px)",
+    desktop: "(min-width: 1024px)",
+  });
+  const breakpoint = useBreakpoint();
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.between}>
+        <div>
+          <p className={styles.eyebrow}>Media query</p>
+          <h4 className={styles.title}>Responsive shell</h4>
+        </div>
+        <span
+          className={`${styles.pill} ${desktop.matches ? styles.pillSuccess : styles.pillNeutral}`}
+        >
+          {desktop.matches ? "Desktop" : "Compact"}
+        </span>
+      </div>
+
+      <div className={styles.surface}>
+        <div className={styles.between}>
+          <div>
+            <p className={styles.eyebrow}>Current breakpoint</p>
+            <h4 className={styles.title}>{breakpoint.breakpoint ?? "base"}</h4>
+            <p className={styles.meta}>matchMedia supported: {String(desktop.supported)}</p>
+          </div>
+          <span
+            className={`${styles.pill} ${
+              breakpoint.supported ? styles.pillSuccess : styles.pillNeutral
+            }`}
+          >
+            {breakpoint.supported ? "Live" : "Fallback"}
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.row}>
+        {Object.entries(screens).map(([name, matches]) => (
+          <span
+            key={name}
+            className={`${styles.pill} ${matches ? styles.pillSuccess : styles.pillNeutral}`}
+          >
+            {name}: {String(matches)}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/docs/content/hooks/_meta.json
+++ b/docs/content/hooks/_meta.json
@@ -5,6 +5,12 @@
     "category": "Hooks",
     "subcategory": "UI"
   },
+  "useMediaQuery": {
+    "title": "useMediaQuery",
+    "order": 2,
+    "category": "Hooks",
+    "subcategory": "UI"
+  },
   "useToggle": "useToggle",
   "useControllableState": "useControllableState",
   "useDisclosure": "useDisclosure",

--- a/docs/content/hooks/useMediaQuery.mdx
+++ b/docs/content/hooks/useMediaQuery.mdx
@@ -1,0 +1,215 @@
+import { DemoFrame } from "../../components/demo-frame";
+import { UseMediaQueryDemo } from "../../components/demos/use-media-query-demo";
+
+# useMediaQuery
+
+`useMediaQuery` is a TypeScript-first React hook for reading CSS media query state in SSR and CSR apps. It accepts a media query `string` and returns a `UseMediaQueryReturn` object with `matches`, `query`, and `supported`, so components can render responsive UI without manually managing `MediaQueryList` listeners.
+
+Internally, it uses `window.matchMedia`, shared subscriptions, and React 18+ `useSyncExternalStore` to keep snapshots hydration-safe and concurrent-rendering friendly. Use it for responsive rendering, preference queries such as reduced motion, and client-only layout state in Next.js apps.
+
+<DemoFrame
+  title="Responsive media state"
+  description="This demo shows a single query, a typed query map, and the default breakpoint helper updating from the same subscription layer."
+>
+  <UseMediaQueryDemo />
+</DemoFrame>
+
+## Install
+
+```bash
+npm install react-rsc-kit
+```
+
+## Import
+
+```tsx
+import { useBreakpoint, useMediaQueries, useMediaQuery } from "react-rsc-kit/client";
+```
+
+## Signature
+
+```ts
+const result = useMediaQuery(query, {
+  defaultValue,
+  ssrValue,
+  initializeWithValue,
+  onChange,
+});
+```
+
+## Parameters
+
+| Name                  | Type                         | Default        | Description                                                                                |
+| --------------------- | ---------------------------- | -------------- | ------------------------------------------------------------------------------------------ |
+| `query`               | `string`                     | required       | CSS media query string passed to `window.matchMedia`.                                      |
+| `defaultValue`        | `boolean`                    | `false`        | Fallback match value before browser resolution or when `matchMedia` is unavailable.        |
+| `ssrValue`            | `boolean`                    | `defaultValue` | Value returned during server rendering and the hydration pass.                             |
+| `initializeWithValue` | `boolean`                    | `true`         | Reads the browser value on the first client render. Set to `false` to start from fallback. |
+| `onChange`            | `(matches: boolean) => void` | `undefined`    | Runs after mount when the resolved match value changes.                                    |
+
+## Returns
+
+| Key         | Type      | Description                                                            |
+| ----------- | --------- | ---------------------------------------------------------------------- |
+| `matches`   | `boolean` | Whether the media query currently matches.                             |
+| `query`     | `string`  | The query string passed to the hook.                                   |
+| `supported` | `boolean` | Whether `window.matchMedia` is available for the query in this render. |
+
+## Usage
+
+```tsx
+"use client";
+
+import { useMediaQuery } from "react-rsc-kit/client";
+
+export function Navigation() {
+  const desktop = useMediaQuery("(min-width: 1024px)", {
+    defaultValue: false,
+    ssrValue: false,
+  });
+
+  return desktop.matches ? <DesktopNav /> : <MobileNav />;
+}
+```
+
+## Advanced Usage
+
+```tsx
+"use client";
+
+import { useMediaQuery } from "react-rsc-kit/client";
+
+export function MotionAwarePanel() {
+  const reducedMotion = useMediaQuery("(prefers-reduced-motion: reduce)", {
+    defaultValue: false,
+    ssrValue: false,
+    initializeWithValue: true,
+    onChange: (matches) => {
+      console.log("Reduced motion:", matches);
+    },
+  });
+
+  return <section data-reduced-motion={reducedMotion.matches} />;
+}
+```
+
+## Multiple Queries
+
+```tsx
+"use client";
+
+import { useMediaQueries } from "react-rsc-kit/client";
+
+export function ResponsiveState() {
+  const screens = useMediaQueries({
+    mobile: "(max-width: 767px)",
+    tablet: "(min-width: 768px)",
+    desktop: "(min-width: 1024px)",
+  });
+
+  return <span>{screens.desktop ? "Desktop" : "Compact"}</span>;
+}
+```
+
+`useMediaQueries` returns a typed boolean map keyed by the object you pass in.
+
+## Breakpoints
+
+```tsx
+"use client";
+
+import { useBreakpoint } from "react-rsc-kit/client";
+
+export function CurrentBreakpoint() {
+  const { breakpoint, matches } = useBreakpoint();
+
+  return (
+    <p>
+      Current: {breakpoint ?? "base"} / large: {String(matches.lg)}
+    </p>
+  );
+}
+```
+
+Default breakpoints:
+
+```ts
+const breakpoints = {
+  sm: "640px",
+  md: "768px",
+  lg: "1024px",
+  xl: "1280px",
+  "2xl": "1536px",
+};
+```
+
+Custom breakpoints:
+
+```tsx
+"use client";
+
+import { useBreakpoint } from "react-rsc-kit/client";
+
+const dashboardBreakpoints = {
+  nav: "900px",
+  analytics: "1180px",
+  wide: "1440px",
+};
+
+export function DashboardShell() {
+  const screen = useBreakpoint({
+    breakpoints: dashboardBreakpoints,
+    ssrValue: false,
+  });
+
+  return <span>{screen.breakpoint ?? "base"}</span>;
+}
+```
+
+## SSR And Next.js
+
+```tsx
+"use client";
+
+import { useMediaQuery } from "react-rsc-kit/client";
+
+export function Sidebar() {
+  const expanded = useMediaQuery("(min-width: 1200px)", {
+    ssrValue: false,
+    defaultValue: false,
+  });
+
+  return <aside data-expanded={expanded.matches} />;
+}
+```
+
+Use hooks from `react-rsc-kit/client` inside files with `"use client"` in the Next.js App Router. `ssrValue` controls the server-rendered value and the hydration snapshot, so the first hydrated client render matches the HTML sent by the server.
+
+## TypeScript
+
+```tsx
+"use client";
+
+import { useMediaQueries } from "react-rsc-kit/client";
+
+const queries = {
+  coarsePointer: "(pointer: coarse)",
+  darkMode: "(prefers-color-scheme: dark)",
+} as const;
+
+export function Preferences() {
+  const preferences = useMediaQueries(queries);
+
+  return <span>{preferences.darkMode ? "Dark" : "Light"}</span>;
+}
+```
+
+## Notes
+
+- The hook uses `useSyncExternalStore`, so server snapshots and client subscriptions follow React's concurrent rendering contract.
+- Repeated use of the same query shares one `MediaQueryList` listener and cleans it up when the last subscriber unmounts.
+- `addEventListener("change", ...)` is used when available, with `addListener` fallback for older browsers.
+- Use `ssrValue` when the server must render a deterministic responsive state.
+- Set `initializeWithValue: false` when the first client render should stay on the fallback value until subscription.
+- Custom breakpoints are evaluated in object order; define them from smallest to largest.
+- Keep query objects stable when practical. Inline objects are supported, but stable constants avoid needless signature work in large trees.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "React hooks and utility components with RSC-safe server/client entrypoints.",
   "author": "react-rsc-kit contributors",
   "license": "MIT",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -14,6 +14,7 @@ export * from "./useGetScrollPosition";
 export * from "./useIntersectionObserver";
 export * from "./useIsomorphicEffect";
 export * from "./useLocalStorage";
+export * from "./useMediaQuery";
 export * from "./useMounted";
 export * from "./useMutation";
 export * from "./useOnScreen";

--- a/src/hooks/useMediaQuery/constants.ts
+++ b/src/hooks/useMediaQuery/constants.ts
@@ -1,0 +1,7 @@
+export const breakpoints = {
+  sm: "640px",
+  md: "768px",
+  lg: "1024px",
+  xl: "1280px",
+  "2xl": "1536px",
+} as const;

--- a/src/hooks/useMediaQuery/index.ts
+++ b/src/hooks/useMediaQuery/index.ts
@@ -1,0 +1,5 @@
+export { breakpoints } from "./constants";
+export * from "./types";
+export { createBreakpointQueries, useBreakpoint } from "./useBreakpoint";
+export { useMediaQueries } from "./useMediaQueries";
+export { useMediaQuery } from "./useMediaQuery";

--- a/src/hooks/useMediaQuery/store.ts
+++ b/src/hooks/useMediaQuery/store.ts
@@ -1,0 +1,203 @@
+export interface MediaQuerySnapshot {
+  matches: boolean;
+  supported: boolean;
+}
+
+interface MediaQueryRecord {
+  query: string;
+  mediaQueryList: MediaQueryList | null;
+  snapshot: MediaQuerySnapshot;
+  listeners: Set<() => void>;
+  removeChangeListener: (() => void) | null;
+}
+
+type LegacyMediaQueryList = MediaQueryList & {
+  addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+  removeListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+};
+
+const supportedTrueSnapshot: MediaQuerySnapshot = {
+  matches: true,
+  supported: true,
+};
+
+const supportedFalseSnapshot: MediaQuerySnapshot = {
+  matches: false,
+  supported: true,
+};
+
+const fallbackTrueSnapshot: MediaQuerySnapshot = {
+  matches: true,
+  supported: false,
+};
+
+const fallbackFalseSnapshot: MediaQuerySnapshot = {
+  matches: false,
+  supported: false,
+};
+
+const mediaQueryRecords = new Map<string, MediaQueryRecord>();
+
+export function getFallbackSnapshot(matches: boolean): MediaQuerySnapshot {
+  return matches ? fallbackTrueSnapshot : fallbackFalseSnapshot;
+}
+
+function getSupportedSnapshot(matches: boolean): MediaQuerySnapshot {
+  return matches ? supportedTrueSnapshot : supportedFalseSnapshot;
+}
+
+export function isMatchMediaSupported(): boolean {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function";
+}
+
+function getMediaQueryList(query: string): MediaQueryList | null {
+  if (!isMatchMediaSupported()) {
+    return null;
+  }
+
+  try {
+    return window.matchMedia(query);
+  } catch {
+    return null;
+  }
+}
+
+function createMediaQueryRecord(query: string): MediaQueryRecord {
+  const mediaQueryList = getMediaQueryList(query);
+
+  return {
+    query,
+    mediaQueryList,
+    snapshot: mediaQueryList ? getSupportedSnapshot(mediaQueryList.matches) : fallbackFalseSnapshot,
+    listeners: new Set(),
+    removeChangeListener: null,
+  };
+}
+
+function getMediaQueryRecord(query: string): MediaQueryRecord {
+  let record = mediaQueryRecords.get(query);
+
+  if (!record) {
+    record = createMediaQueryRecord(query);
+    mediaQueryRecords.set(query, record);
+  }
+
+  return record;
+}
+
+function ensureMediaQueryList(record: MediaQueryRecord): void {
+  if (record.mediaQueryList !== null) {
+    return;
+  }
+
+  const mediaQueryList = getMediaQueryList(record.query);
+
+  if (mediaQueryList === null) {
+    return;
+  }
+
+  record.mediaQueryList = mediaQueryList;
+  record.snapshot = getSupportedSnapshot(mediaQueryList.matches);
+}
+
+function updateRecordSnapshot(record: MediaQueryRecord): boolean {
+  ensureMediaQueryList(record);
+
+  const nextSnapshot =
+    record.mediaQueryList === null
+      ? fallbackFalseSnapshot
+      : getSupportedSnapshot(record.mediaQueryList.matches);
+
+  if (Object.is(record.snapshot, nextSnapshot)) {
+    return false;
+  }
+
+  record.snapshot = nextSnapshot;
+  return true;
+}
+
+function notifyRecordListeners(record: MediaQueryRecord): void {
+  if (!updateRecordSnapshot(record)) {
+    return;
+  }
+
+  record.listeners.forEach((listener) => {
+    listener();
+  });
+}
+
+function addMediaQueryListListener(
+  mediaQueryList: LegacyMediaQueryList,
+  listener: (event: MediaQueryListEvent) => void,
+): () => void {
+  if (typeof mediaQueryList.addEventListener === "function") {
+    mediaQueryList.addEventListener("change", listener);
+
+    return () => {
+      mediaQueryList.removeEventListener("change", listener);
+    };
+  }
+
+  if (typeof mediaQueryList.addListener === "function") {
+    mediaQueryList.addListener(listener);
+
+    return () => {
+      mediaQueryList.removeListener?.(listener);
+    };
+  }
+
+  return () => {};
+}
+
+function ensureChangeListener(record: MediaQueryRecord): void {
+  if (record.removeChangeListener !== null || record.mediaQueryList === null) {
+    return;
+  }
+
+  const listener = () => {
+    notifyRecordListeners(record);
+  };
+
+  record.removeChangeListener = addMediaQueryListListener(record.mediaQueryList, listener);
+}
+
+export function getMediaQuerySnapshot(query: string): MediaQuerySnapshot {
+  const record = getMediaQueryRecord(query);
+
+  updateRecordSnapshot(record);
+  return record.snapshot;
+}
+
+export function subscribeToMediaQuery(query: string, listener: () => void): () => void {
+  const record = getMediaQueryRecord(query);
+
+  ensureMediaQueryList(record);
+  record.listeners.add(listener);
+  ensureChangeListener(record);
+
+  return () => {
+    record.listeners.delete(listener);
+
+    if (record.listeners.size > 0) {
+      return;
+    }
+
+    record.removeChangeListener?.();
+    record.removeChangeListener = null;
+    mediaQueryRecords.delete(query);
+  };
+}
+
+export function subscribeToMediaQueries(
+  queries: readonly string[],
+  listener: () => void,
+): () => void {
+  const uniqueQueries = Array.from(new Set(queries));
+  const unsubscribers = uniqueQueries.map((query) => subscribeToMediaQuery(query, listener));
+
+  return () => {
+    unsubscribers.forEach((unsubscribe) => {
+      unsubscribe();
+    });
+  };
+}

--- a/src/hooks/useMediaQuery/types.ts
+++ b/src/hooks/useMediaQuery/types.ts
@@ -1,0 +1,108 @@
+export interface UseMediaQueryOptions {
+  /**
+   * Value used before the browser can resolve the query, or when `matchMedia` is unavailable.
+   */
+  defaultValue?: boolean;
+
+  /**
+   * Value returned during server rendering and the hydration pass.
+   * Defaults to `defaultValue`.
+   */
+  ssrValue?: boolean;
+
+  /**
+   * Read the browser value during the first client render.
+   * Set this to `false` when you want the first client snapshot to stay on the fallback value.
+   */
+  initializeWithValue?: boolean;
+
+  /**
+   * Called after mount when the resolved match value changes.
+   */
+  onChange?: (matches: boolean) => void;
+}
+
+export interface UseMediaQueryReturn {
+  /**
+   * Whether the media query currently matches.
+   */
+  matches: boolean;
+
+  /**
+   * The media query string passed to the hook.
+   */
+  query: string;
+
+  /**
+   * Whether `window.matchMedia` is available for this query in the current environment.
+   */
+  supported: boolean;
+}
+
+export type MediaQueryMap = Record<string, string>;
+
+export type UseMediaQueriesReturn<TQueries extends MediaQueryMap> = {
+  readonly [Key in keyof TQueries]: boolean;
+};
+
+export interface UseMediaQueriesOptions<
+  TQueries extends MediaQueryMap = MediaQueryMap,
+> extends Omit<UseMediaQueryOptions, "onChange"> {
+  /**
+   * Called after mount when any resolved query match value changes.
+   */
+  onChange?: (matches: UseMediaQueriesReturn<TQueries>) => void;
+}
+
+export type BreakpointMap = Record<string, string>;
+
+export type BreakpointMatches<TBreakpoints extends BreakpointMap> = {
+  readonly [Key in keyof TBreakpoints]: boolean;
+};
+
+export interface UseBreakpointOptions<
+  TBreakpoints extends BreakpointMap = BreakpointMap,
+> extends Omit<
+  UseMediaQueriesOptions<Record<Extract<keyof TBreakpoints, string>, string>>,
+  "onChange"
+> {
+  /**
+   * Named breakpoint widths ordered from smallest to largest.
+   */
+  breakpoints?: TBreakpoints;
+
+  /**
+   * Called after mount when the active breakpoint changes.
+   */
+  onChange?: (
+    breakpoint: Extract<keyof TBreakpoints, string> | null,
+    matches: BreakpointMatches<TBreakpoints>,
+  ) => void;
+}
+
+export interface UseBreakpointReturn<TBreakpoints extends BreakpointMap = BreakpointMap> {
+  /**
+   * Largest matching breakpoint key, or `null` when no breakpoint matches.
+   */
+  breakpoint: Extract<keyof TBreakpoints, string> | null;
+
+  /**
+   * Match state for every configured breakpoint.
+   */
+  matches: BreakpointMatches<TBreakpoints>;
+
+  /**
+   * Media query string for every configured breakpoint.
+   */
+  queries: Record<Extract<keyof TBreakpoints, string>, string>;
+
+  /**
+   * Breakpoint widths used to build the queries.
+   */
+  breakpoints: TBreakpoints;
+
+  /**
+   * Whether `window.matchMedia` is available for all configured breakpoint queries.
+   */
+  supported: boolean;
+}

--- a/src/hooks/useMediaQuery/useBreakpoint.ts
+++ b/src/hooks/useMediaQuery/useBreakpoint.ts
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useRef } from "react";
+
+import { breakpoints as defaultBreakpoints } from "./constants";
+import {
+  BreakpointMap,
+  BreakpointMatches,
+  UseBreakpointOptions,
+  UseBreakpointReturn,
+} from "./types";
+import { useMediaQueriesState } from "./useMediaQueries";
+
+type BreakpointName<TBreakpoints extends BreakpointMap> = Extract<keyof TBreakpoints, string>;
+type BreakpointEntries<TBreakpoints extends BreakpointMap> = Array<
+  [BreakpointName<TBreakpoints>, string]
+>;
+
+function getBreakpointEntries<TBreakpoints extends BreakpointMap>(
+  breakpointMap: TBreakpoints,
+): BreakpointEntries<TBreakpoints> {
+  return Object.entries(breakpointMap) as BreakpointEntries<TBreakpoints>;
+}
+
+function getBreakpointSignature(entries: readonly [string, string][]): string {
+  return JSON.stringify(entries);
+}
+
+function createBreakpointQueriesFromEntries<TBreakpoints extends BreakpointMap>(
+  entries: BreakpointEntries<TBreakpoints>,
+): Record<BreakpointName<TBreakpoints>, string> {
+  const queries = {} as Record<BreakpointName<TBreakpoints>, string>;
+
+  entries.forEach(([key, value]) => {
+    queries[key] = `(min-width: ${value})`;
+  });
+
+  return queries;
+}
+
+export function createBreakpointQueries<TBreakpoints extends BreakpointMap>(
+  breakpointMap: TBreakpoints,
+): Record<BreakpointName<TBreakpoints>, string> {
+  return createBreakpointQueriesFromEntries(getBreakpointEntries(breakpointMap));
+}
+
+function getActiveBreakpoint<TBreakpoints extends BreakpointMap>(
+  entries: BreakpointEntries<TBreakpoints>,
+  matches: BreakpointMatches<TBreakpoints>,
+): BreakpointName<TBreakpoints> | null {
+  let activeBreakpoint: BreakpointName<TBreakpoints> | null = null;
+
+  entries.forEach(([key]) => {
+    if (matches[key]) {
+      activeBreakpoint = key;
+    }
+  });
+
+  return activeBreakpoint;
+}
+
+/**
+ * Resolve the active breakpoint from configurable min-width media queries.
+ */
+export function useBreakpoint<TBreakpoints extends BreakpointMap = typeof defaultBreakpoints>(
+  options: UseBreakpointOptions<TBreakpoints> = {},
+): UseBreakpointReturn<TBreakpoints> {
+  const {
+    breakpoints: breakpointMap = defaultBreakpoints as unknown as TBreakpoints,
+    onChange,
+    ...mediaQueryOptions
+  } = options;
+  const entries = getBreakpointEntries(breakpointMap);
+  const signature = getBreakpointSignature(entries);
+  const stableBreakpointMap = useMemo(() => breakpointMap, [signature]);
+  const stableEntries = useMemo(() => entries, [signature]);
+  const queries = useMemo(() => createBreakpointQueriesFromEntries(stableEntries), [stableEntries]);
+  const snapshot = useMediaQueriesState(queries, mediaQueryOptions);
+  const matches = snapshot.matches as BreakpointMatches<TBreakpoints>;
+  const activeBreakpoint = useMemo(
+    () => getActiveBreakpoint(stableEntries, matches),
+    [matches, stableEntries],
+  );
+  const previousBreakpointRef = useRef(activeBreakpoint);
+  const hasMountedRef = useRef(false);
+  const onChangeRef = useRef(onChange);
+
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      previousBreakpointRef.current = activeBreakpoint;
+      return;
+    }
+
+    if (Object.is(previousBreakpointRef.current, activeBreakpoint)) {
+      return;
+    }
+
+    previousBreakpointRef.current = activeBreakpoint;
+    onChangeRef.current?.(activeBreakpoint, matches);
+  }, [activeBreakpoint, matches]);
+
+  return useMemo<UseBreakpointReturn<TBreakpoints>>(
+    () => ({
+      breakpoint: activeBreakpoint,
+      matches,
+      queries,
+      breakpoints: stableBreakpointMap,
+      supported: snapshot.supported,
+    }),
+    [activeBreakpoint, matches, queries, snapshot.supported, stableBreakpointMap],
+  );
+}

--- a/src/hooks/useMediaQuery/useMediaQueries.ts
+++ b/src/hooks/useMediaQuery/useMediaQueries.ts
@@ -1,0 +1,191 @@
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+} from "react";
+
+import {
+  getFallbackSnapshot,
+  getMediaQuerySnapshot,
+  isMatchMediaSupported,
+  subscribeToMediaQueries,
+} from "./store";
+import { MediaQueryMap, UseMediaQueriesOptions, UseMediaQueriesReturn } from "./types";
+
+const DEFAULT_VALUE = false;
+
+interface MediaQueriesSnapshot<TQueries extends MediaQueryMap> {
+  matches: UseMediaQueriesReturn<TQueries>;
+  supported: boolean;
+}
+
+interface CachedMediaQueriesSnapshot<
+  TQueries extends MediaQueryMap,
+> extends MediaQueriesSnapshot<TQueries> {
+  signature: string;
+}
+
+type MediaQueryEntries<TQueries extends MediaQueryMap> = Array<
+  [Extract<keyof TQueries, string>, string]
+>;
+
+function getMediaQueryEntries<TQueries extends MediaQueryMap>(
+  queries: TQueries,
+): MediaQueryEntries<TQueries> {
+  return Object.entries(queries) as MediaQueryEntries<TQueries>;
+}
+
+function getMediaQuerySignature(entries: readonly [string, string][]): string {
+  return JSON.stringify(entries);
+}
+
+function areMatchesEqual<TQueries extends MediaQueryMap>(
+  previousMatches: UseMediaQueriesReturn<TQueries>,
+  nextMatches: UseMediaQueriesReturn<TQueries>,
+  entries: MediaQueryEntries<TQueries>,
+): boolean {
+  return entries.every(([key]) => Object.is(previousMatches[key], nextMatches[key]));
+}
+
+function resolveMediaQueriesSnapshot<TQueries extends MediaQueryMap>({
+  cacheRef,
+  defaultValue,
+  entries,
+  forceFallback,
+  signature,
+}: {
+  cacheRef: MutableRefObject<CachedMediaQueriesSnapshot<TQueries> | null>;
+  defaultValue: boolean;
+  entries: MediaQueryEntries<TQueries>;
+  forceFallback: boolean;
+  signature: string;
+}): MediaQueriesSnapshot<TQueries> {
+  const matches = {} as Record<Extract<keyof TQueries, string>, boolean>;
+  let supported = entries.length === 0 ? !forceFallback && isMatchMediaSupported() : true;
+
+  entries.forEach(([key, query]) => {
+    const snapshot = forceFallback
+      ? getFallbackSnapshot(defaultValue)
+      : getMediaQuerySnapshot(query);
+    const resolvedSnapshot = snapshot.supported ? snapshot : getFallbackSnapshot(defaultValue);
+
+    matches[key] = resolvedSnapshot.matches;
+    supported = supported && resolvedSnapshot.supported;
+  });
+
+  const nextSnapshot: MediaQueriesSnapshot<TQueries> = {
+    matches: matches as UseMediaQueriesReturn<TQueries>,
+    supported,
+  };
+  const cachedSnapshot = cacheRef.current;
+
+  if (
+    cachedSnapshot &&
+    cachedSnapshot.signature === signature &&
+    cachedSnapshot.supported === nextSnapshot.supported &&
+    areMatchesEqual(cachedSnapshot.matches, nextSnapshot.matches, entries)
+  ) {
+    return cachedSnapshot;
+  }
+
+  const snapshotWithSignature: CachedMediaQueriesSnapshot<TQueries> = {
+    ...nextSnapshot,
+    signature,
+  };
+
+  cacheRef.current = snapshotWithSignature;
+  return snapshotWithSignature;
+}
+
+export function useMediaQueriesState<TQueries extends MediaQueryMap>(
+  queries: TQueries,
+  options: UseMediaQueriesOptions<TQueries> = {},
+): MediaQueriesSnapshot<TQueries> {
+  const {
+    defaultValue = DEFAULT_VALUE,
+    ssrValue = defaultValue,
+    initializeWithValue = true,
+    onChange,
+  } = options;
+  const entries = getMediaQueryEntries(queries);
+  const signature = getMediaQuerySignature(entries);
+  const stableEntries = useMemo(() => entries, [signature]);
+  const queryList = useMemo(() => stableEntries.map(([, query]) => query), [stableEntries]);
+  const cacheRef = useRef<CachedMediaQueriesSnapshot<TQueries> | null>(null);
+  const currentSignatureRef = useRef(signature);
+  const didSubscribeRef = useRef(false);
+  const onChangeRef = useRef(onChange);
+
+  onChangeRef.current = onChange;
+
+  if (currentSignatureRef.current !== signature) {
+    currentSignatureRef.current = signature;
+    didSubscribeRef.current = false;
+  }
+
+  const getSnapshot = useCallback(
+    () =>
+      resolveMediaQueriesSnapshot<TQueries>({
+        cacheRef,
+        defaultValue,
+        entries: stableEntries,
+        forceFallback: !initializeWithValue && !didSubscribeRef.current,
+        signature,
+      }),
+    [defaultValue, initializeWithValue, signature, stableEntries],
+  );
+
+  const getServerSnapshot = useCallback(
+    () =>
+      resolveMediaQueriesSnapshot<TQueries>({
+        cacheRef,
+        defaultValue: ssrValue,
+        entries: stableEntries,
+        forceFallback: true,
+        signature,
+      }),
+    [signature, ssrValue, stableEntries],
+  );
+
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      didSubscribeRef.current = true;
+      return subscribeToMediaQueries(queryList, listener);
+    },
+    [queryList],
+  );
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const previousMatchesRef = useRef(snapshot.matches);
+  const hasMountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      previousMatchesRef.current = snapshot.matches;
+      return;
+    }
+
+    if (areMatchesEqual(previousMatchesRef.current, snapshot.matches, stableEntries)) {
+      return;
+    }
+
+    previousMatchesRef.current = snapshot.matches;
+    onChangeRef.current?.(snapshot.matches);
+  }, [snapshot.matches, stableEntries]);
+
+  return snapshot;
+}
+
+/**
+ * Subscribe to several CSS media queries and return a typed map of match values.
+ */
+export function useMediaQueries<TQueries extends MediaQueryMap>(
+  queries: TQueries,
+  options: UseMediaQueriesOptions<TQueries> = {},
+): UseMediaQueriesReturn<TQueries> {
+  return useMediaQueriesState(queries, options).matches;
+}

--- a/src/hooks/useMediaQuery/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery/useMediaQuery.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
+
+import {
+  getFallbackSnapshot,
+  getMediaQuerySnapshot,
+  MediaQuerySnapshot,
+  subscribeToMediaQuery,
+} from "./store";
+import { UseMediaQueryOptions, UseMediaQueryReturn } from "./types";
+
+const DEFAULT_VALUE = false;
+
+/**
+ * Subscribe to a CSS media query with SSR-safe snapshots and shared browser listeners.
+ */
+export function useMediaQuery(
+  query: string,
+  options: UseMediaQueryOptions = {},
+): UseMediaQueryReturn {
+  const {
+    defaultValue = DEFAULT_VALUE,
+    ssrValue = defaultValue,
+    initializeWithValue = true,
+    onChange,
+  } = options;
+
+  const onChangeRef = useRef(onChange);
+  const didSubscribeRef = useRef(false);
+  const currentQueryRef = useRef(query);
+
+  onChangeRef.current = onChange;
+
+  if (currentQueryRef.current !== query) {
+    currentQueryRef.current = query;
+    didSubscribeRef.current = false;
+  }
+
+  const getSnapshot = useCallback((): MediaQuerySnapshot => {
+    if (!initializeWithValue && !didSubscribeRef.current) {
+      return getFallbackSnapshot(defaultValue);
+    }
+
+    const snapshot = getMediaQuerySnapshot(query);
+    return snapshot.supported ? snapshot : getFallbackSnapshot(defaultValue);
+  }, [defaultValue, initializeWithValue, query]);
+
+  const getServerSnapshot = useCallback(() => getFallbackSnapshot(ssrValue), [ssrValue]);
+
+  const subscribe = useCallback(
+    (listener: () => void) => {
+      didSubscribeRef.current = true;
+      return subscribeToMediaQuery(query, listener);
+    },
+    [query],
+  );
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const matches = snapshot.matches;
+  const supported = snapshot.supported;
+  const previousMatchesRef = useRef(matches);
+  const hasMountedRef = useRef(false);
+
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      previousMatchesRef.current = matches;
+      return;
+    }
+
+    if (Object.is(previousMatchesRef.current, matches)) {
+      return;
+    }
+
+    previousMatchesRef.current = matches;
+    onChangeRef.current?.(matches);
+  }, [matches]);
+
+  return useMemo<UseMediaQueryReturn>(
+    () => ({
+      matches,
+      query,
+      supported,
+    }),
+    [matches, query, supported],
+  );
+}

--- a/tests/use-media-query.ssr.test.tsx
+++ b/tests/use-media-query.ssr.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment node
+
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { useBreakpoint, useMediaQueries, useMediaQuery } from "../src/client/hooks";
+
+describe("useMediaQuery SSR", () => {
+  it("renders useMediaQuery safely on the server with the ssrValue snapshot", () => {
+    function ServerRenderedQuery() {
+      const result = useMediaQuery("(min-width: 1024px)", {
+        defaultValue: false,
+        ssrValue: true,
+      });
+
+      return <span>{`${String(result.matches)}:${String(result.supported)}`}</span>;
+    }
+
+    expect(renderToString(<ServerRenderedQuery />)).toContain("<span>true:false</span>");
+  });
+
+  it("renders useMediaQueries and useBreakpoint safely on the server", () => {
+    function ServerRenderedQueries() {
+      const screens = useMediaQueries(
+        {
+          mobile: "(max-width: 767px)",
+          desktop: "(min-width: 1024px)",
+        },
+        {
+          ssrValue: false,
+        },
+      );
+      const breakpoint = useBreakpoint({
+        ssrValue: false,
+      });
+
+      return (
+        <span>{`${String(screens.mobile)}:${breakpoint.breakpoint ?? "base"}:${String(
+          breakpoint.supported,
+        )}`}</span>
+      );
+    }
+
+    expect(renderToString(<ServerRenderedQueries />)).toContain("<span>false:base:false</span>");
+  });
+});

--- a/tests/use-media-query.test.tsx
+++ b/tests/use-media-query.test.tsx
@@ -1,0 +1,492 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { ReactNode, StrictMode } from "react";
+import { hydrateRoot, Root } from "react-dom/client";
+import { renderToString } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useBreakpoint, useMediaQueries, useMediaQuery } from "../src/client/hooks";
+
+type MediaQueryListener = (event: MediaQueryListEvent) => void;
+
+class MockMediaQueryList {
+  readonly media: string;
+  matches: boolean;
+  onchange: MediaQueryListener | null = null;
+  readonly addListener = vi.fn((listener: MediaQueryListener) => {
+    this.legacyListeners.add(listener);
+  });
+  readonly removeListener = vi.fn((listener: MediaQueryListener) => {
+    this.legacyListeners.delete(listener);
+  });
+  addEventListener?: MediaQueryList["addEventListener"];
+  removeEventListener?: MediaQueryList["removeEventListener"];
+
+  private readonly modernListeners = new Set<EventListenerOrEventListenerObject>();
+  private readonly legacyListeners = new Set<MediaQueryListener>();
+
+  constructor(query: string, matches: boolean, legacy = false) {
+    this.media = query;
+    this.matches = matches;
+
+    if (!legacy) {
+      this.addEventListener = vi.fn(
+        (type: string, listener: EventListenerOrEventListenerObject) => {
+          if (type === "change") {
+            this.modernListeners.add(listener);
+          }
+        },
+      ) as MediaQueryList["addEventListener"];
+      this.removeEventListener = vi.fn(
+        (type: string, listener: EventListenerOrEventListenerObject) => {
+          if (type === "change") {
+            this.modernListeners.delete(listener);
+          }
+        },
+      ) as MediaQueryList["removeEventListener"];
+    }
+  }
+
+  get listenerCount() {
+    return this.modernListeners.size + this.legacyListeners.size;
+  }
+
+  trigger(matches: boolean) {
+    this.matches = matches;
+    const event = {
+      matches,
+      media: this.media,
+    } as MediaQueryListEvent;
+
+    this.onchange?.(event);
+    this.modernListeners.forEach((listener) => {
+      if (typeof listener === "function") {
+        listener(event);
+        return;
+      }
+
+      listener.handleEvent(event);
+    });
+    this.legacyListeners.forEach((listener) => {
+      listener(event);
+    });
+  }
+
+  dispatchEvent(): boolean {
+    return true;
+  }
+}
+
+const originalMatchMediaDescriptor = Object.getOwnPropertyDescriptor(window, "matchMedia");
+
+function restoreMatchMedia() {
+  if (originalMatchMediaDescriptor) {
+    Object.defineProperty(window, "matchMedia", originalMatchMediaDescriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(window, "matchMedia");
+}
+
+function installMatchMedia(
+  initialMatches: Record<string, boolean> = {},
+  options: { legacy?: boolean } = {},
+) {
+  const lists = new Map<string, MockMediaQueryList>();
+  const matchMedia = vi.fn((query: string) => {
+    let list = lists.get(query);
+
+    if (!list) {
+      list = new MockMediaQueryList(query, initialMatches[query] ?? false, options.legacy);
+      lists.set(query, list);
+    }
+
+    return list as unknown as MediaQueryList;
+  });
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+
+  return {
+    get(query: string) {
+      matchMedia(query);
+      return lists.get(query) as MockMediaQueryList;
+    },
+    matchMedia,
+  };
+}
+
+describe("useMediaQuery", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreMatchMedia();
+  });
+
+  it("reads the browser query value and keeps stable output when nothing changes", () => {
+    const query = "(min-width: 1024px)";
+    const mock = installMatchMedia({
+      [query]: true,
+    });
+    const { result, rerender } = renderHook(() => useMediaQuery(query));
+    const firstResult = result.current;
+
+    expect(result.current).toEqual({
+      matches: true,
+      query,
+      supported: true,
+    });
+    expect(mock.get(query).listenerCount).toBe(1);
+
+    rerender();
+
+    expect(result.current).toBe(firstResult);
+    expect(mock.get(query).addEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("updates when the media query changes and calls onChange after mount", () => {
+    const query = "(prefers-reduced-motion: reduce)";
+    const onChange = vi.fn();
+    const mock = installMatchMedia({
+      [query]: false,
+    });
+    const { result } = renderHook(() =>
+      useMediaQuery(query, {
+        onChange,
+      }),
+    );
+
+    act(() => {
+      mock.get(query).trigger(true);
+    });
+
+    expect(result.current.matches).toBe(true);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it("resubscribes safely when the query changes", () => {
+    const firstQuery = "(min-width: 768px)";
+    const nextQuery = "(min-width: 1280px)";
+    const mock = installMatchMedia({
+      [firstQuery]: false,
+      [nextQuery]: true,
+    });
+    const { result, rerender } = renderHook(
+      ({ query }: { query: string }) => useMediaQuery(query),
+      {
+        initialProps: {
+          query: firstQuery,
+        },
+      },
+    );
+
+    expect(result.current.matches).toBe(false);
+    expect(mock.get(firstQuery).listenerCount).toBe(1);
+
+    rerender({
+      query: nextQuery,
+    });
+
+    expect(result.current).toEqual({
+      matches: true,
+      query: nextQuery,
+      supported: true,
+    });
+    expect(mock.get(firstQuery).listenerCount).toBe(0);
+    expect(mock.get(nextQuery).listenerCount).toBe(1);
+  });
+
+  it("cleans up listeners on unmount", () => {
+    const query = "(min-width: 900px)";
+    const mock = installMatchMedia();
+    const { unmount } = renderHook(() => useMediaQuery(query));
+
+    expect(mock.get(query).listenerCount).toBe(1);
+
+    unmount();
+
+    expect(mock.get(query).listenerCount).toBe(0);
+    expect(mock.get(query).removeEventListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares one MediaQueryList listener across multiple subscribers", () => {
+    const query = "(min-width: 1024px)";
+    const mock = installMatchMedia({
+      [query]: false,
+    });
+    const { result, unmount } = renderHook(
+      () => [useMediaQuery(query), useMediaQuery(query)] as const,
+    );
+
+    expect(mock.get(query).listenerCount).toBe(1);
+
+    act(() => {
+      mock.get(query).trigger(true);
+    });
+
+    expect(result.current[0].matches).toBe(true);
+    expect(result.current[1].matches).toBe(true);
+
+    unmount();
+
+    expect(mock.get(query).listenerCount).toBe(0);
+  });
+
+  it("falls back when matchMedia is unavailable", () => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    const { result } = renderHook(() =>
+      useMediaQuery("(min-width: 1024px)", {
+        defaultValue: true,
+      }),
+    );
+
+    expect(result.current.matches).toBe(true);
+    expect(result.current.supported).toBe(false);
+  });
+
+  it("can delay the first client snapshot until subscription", async () => {
+    const query = "(min-width: 1024px)";
+    installMatchMedia({
+      [query]: true,
+    });
+    const renderValues: boolean[] = [];
+    const { result } = renderHook(() => {
+      const mediaQuery = useMediaQuery(query, {
+        defaultValue: false,
+        initializeWithValue: false,
+      });
+
+      renderValues.push(mediaQuery.matches);
+      return mediaQuery;
+    });
+
+    expect(renderValues[0]).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.matches).toBe(true);
+    });
+  });
+
+  it("uses addListener and removeListener in legacy environments", () => {
+    const query = "(min-width: 1024px)";
+    const mock = installMatchMedia({}, { legacy: true });
+    const { result, unmount } = renderHook(() => useMediaQuery(query));
+
+    expect(mock.get(query).addEventListener).toBeUndefined();
+    expect(mock.get(query).addListener).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      mock.get(query).trigger(true);
+    });
+
+    expect(result.current.matches).toBe(true);
+
+    unmount();
+
+    expect(mock.get(query).removeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps one active listener under StrictMode double mounting", () => {
+    const query = "(min-width: 1024px)";
+    const mock = installMatchMedia();
+    const wrapper = ({ children }: { children: ReactNode }) => <StrictMode>{children}</StrictMode>;
+    const { unmount } = renderHook(() => useMediaQuery(query), {
+      wrapper,
+    });
+
+    expect(mock.get(query).listenerCount).toBe(1);
+
+    unmount();
+
+    expect(mock.get(query).listenerCount).toBe(0);
+  });
+
+  it("hydrates with the server snapshot and updates after subscription without mismatch", async () => {
+    const query = "(min-width: 1024px)";
+    const mock = installMatchMedia({
+      [query]: true,
+    });
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    function ResponsiveLabel() {
+      const desktop = useMediaQuery(query, {
+        defaultValue: false,
+        ssrValue: false,
+      });
+
+      return <span>{String(desktop.matches)}</span>;
+    }
+
+    const html = renderToString(<ResponsiveLabel />);
+    const container = document.createElement("div");
+    let root: Root | null = null;
+
+    container.innerHTML = html;
+    expect(container.textContent).toBe("false");
+
+    await act(async () => {
+      root = hydrateRoot(container, <ResponsiveLabel />);
+    });
+
+    await waitFor(() => {
+      expect(container.textContent).toBe("true");
+    });
+
+    const hydrationErrors = consoleError.mock.calls.filter(([message]) =>
+      String(message).toLowerCase().includes("hydration"),
+    );
+
+    expect(hydrationErrors).toHaveLength(0);
+    expect(mock.get(query).listenerCount).toBe(1);
+
+    await act(async () => {
+      root?.unmount();
+    });
+  });
+});
+
+describe("useMediaQueries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreMatchMedia();
+  });
+
+  it("returns a typed match map and updates changed queries", () => {
+    const queries = {
+      mobile: "(max-width: 767px)",
+      desktop: "(min-width: 1024px)",
+    };
+    const onChange = vi.fn();
+    const mock = installMatchMedia({
+      [queries.mobile]: true,
+      [queries.desktop]: false,
+    });
+    const { result } = renderHook(() =>
+      useMediaQueries(queries, {
+        onChange,
+      }),
+    );
+
+    expect(result.current).toEqual({
+      mobile: true,
+      desktop: false,
+    });
+
+    act(() => {
+      mock.get(queries.desktop).trigger(true);
+    });
+
+    expect(result.current).toEqual({
+      mobile: true,
+      desktop: true,
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      mobile: true,
+      desktop: true,
+    });
+  });
+
+  it("supports dynamic query maps without changing hook order", () => {
+    const firstQueries = {
+      compact: "(max-width: 767px)",
+    };
+    const nextQueries = {
+      compact: "(max-width: 767px)",
+      wide: "(min-width: 1280px)",
+    };
+    const mock = installMatchMedia({
+      [firstQueries.compact]: false,
+      [nextQueries.wide]: true,
+    });
+    const { result, rerender } = renderHook(
+      ({ queries }: { queries: Record<string, string> }) => useMediaQueries(queries),
+      {
+        initialProps: {
+          queries: firstQueries,
+        },
+      },
+    );
+
+    expect(result.current).toEqual({
+      compact: false,
+    });
+
+    rerender({
+      queries: nextQueries,
+    });
+
+    expect(result.current).toEqual({
+      compact: false,
+      wide: true,
+    });
+    expect(mock.get(firstQueries.compact).listenerCount).toBe(1);
+    expect(mock.get(nextQueries.wide).listenerCount).toBe(1);
+  });
+});
+
+describe("useBreakpoint", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    restoreMatchMedia();
+  });
+
+  it("returns the largest matching default breakpoint", () => {
+    installMatchMedia({
+      "(min-width: 640px)": true,
+      "(min-width: 768px)": true,
+      "(min-width: 1024px)": false,
+      "(min-width: 1280px)": false,
+      "(min-width: 1536px)": false,
+    });
+
+    const { result } = renderHook(() => useBreakpoint());
+
+    expect(result.current.breakpoint).toBe("md");
+    expect(result.current.matches).toEqual({
+      sm: true,
+      md: true,
+      lg: false,
+      xl: false,
+      "2xl": false,
+    });
+    expect(result.current.queries.lg).toBe("(min-width: 1024px)");
+    expect(result.current.supported).toBe(true);
+  });
+
+  it("supports custom breakpoints and onChange", () => {
+    const customBreakpoints = {
+      tablet: "768px",
+      desktop: "1024px",
+    } as const;
+    const onChange = vi.fn();
+    const mock = installMatchMedia({
+      "(min-width: 768px)": true,
+      "(min-width: 1024px)": false,
+    });
+    const { result } = renderHook(() =>
+      useBreakpoint({
+        breakpoints: customBreakpoints,
+        onChange,
+      }),
+    );
+
+    expect(result.current.breakpoint).toBe("tablet");
+
+    act(() => {
+      mock.get("(min-width: 1024px)").trigger(true);
+    });
+
+    expect(result.current.breakpoint).toBe("desktop");
+    expect(onChange).toHaveBeenCalledWith("desktop", {
+      tablet: true,
+      desktop: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

**What does this PR change?**

This PR adds a production-ready `useMediaQuery` hook family:

- `useMediaQuery(query, options)`
- `useMediaQueries(queries, options)`
- `useBreakpoint(options)`

It includes SSR/CSR-safe implementation using `useSyncExternalStore`, shared `matchMedia` subscriptions, legacy listener fallback, dynamic query support, TypeScript types, barrel exports, docs, live docs demo, and tests for SSR, hydration, cleanup, fallback behavior, StrictMode, multi-query usage, and breakpoints.

**Why is it needed?**

Apps often need responsive state in React components without manually wiring `window.matchMedia`. This gives the package a reliable, typed, Next.js-friendly media query API that prevents hydration mismatches, avoids duplicate listeners across large apps, cleans up safely, and works in unsupported or server environments with predictable fallback values.

## Checklist

- [x] Tests added/updated
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] `npm run build` passes
- [x] Docs/README updated if API changed
