### PR TITLE
use window size hook

### DIFF
--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -22,7 +22,7 @@ typed reusable React hooks, small utility components, and clear client/server bo
 - [x] `useControllableState`
 - [x] `useDisclosure`
 - [x] `useMediaQuery`
-- [ ] `useWindowSize`
+- [x] `useWindowSize`
 - [ ] `useResizeObserver` or `useElementSize`
 - [ ] `useLockBodyScroll`
 - [ ] `useHotkeys`

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Layout, Navbar, ThemeSwitch } from "nextra-theme-docs";
 import { getPageMap } from "nextra/page-map";
 
+import packageJson from "../../package.json";
 import { DocsSearch } from "../components/docs-search";
 import { SiteLogo } from "../components/site-logo";
 import "../styles/index.css";
@@ -13,6 +14,7 @@ const inter = Inter({
   subsets: ["latin"],
   display: "swap",
 });
+const packageVersion = packageJson.version;
 
 function NpmIcon(props: SVGProps<SVGSVGElement>) {
   return (
@@ -273,7 +275,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
           }}
           navbar={
             <Navbar
-              logo={<SiteLogo compact />}
+              logo={<SiteLogo compact version={packageVersion} />}
               projectLink="https://github.com/thepuskar/react-rsc-kit"
               className="react-rsc-kit-navbar"
             >

--- a/docs/app/layout.tsx
+++ b/docs/app/layout.tsx
@@ -283,7 +283,7 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
             </Navbar>
           }
           footer={<SiteFooter />}
-          copyPageButton={false}
+          copyPageButton
         >
           {children}
         </Layout>

--- a/docs/components/demos/use-window-size-demo.tsx
+++ b/docs/components/demos/use-window-size-demo.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useWindowSize } from "react-rsc-kit/client";
+
+import styles from "./demo-tokens.module.css";
+
+const dashboardBreakpoints = {
+  compact: 480,
+  workspace: 900,
+  command: 1200,
+} as const;
+
+export function UseWindowSizeDemo() {
+  const size = useWindowSize({
+    breakpoints: dashboardBreakpoints,
+    throttleMs: 100,
+    round: true,
+  });
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.between}>
+        <div>
+          <p className={styles.eyebrow}>Viewport</p>
+          <h4 className={styles.title}>
+            {size.width} x {size.height}
+          </h4>
+          <p className={styles.meta}>
+            visual: {size.visualWidth} x {size.visualHeight} / DPR: {size.devicePixelRatio}
+          </p>
+        </div>
+        <span className={`${styles.pill} ${styles.pillSuccess}`}>
+          {size.isClient ? "Client" : "Server"}
+        </span>
+      </div>
+
+      <div className={styles.surface}>
+        <div className={styles.between}>
+          <div>
+            <p className={styles.eyebrow}>Layout state</p>
+            <h4 className={styles.title}>{size.breakpoint ?? "base"}</h4>
+            <p className={styles.meta}>
+              {size.orientation} / remount key: {size.remountKey}
+            </p>
+          </div>
+          <span
+            className={`${styles.pill} ${
+              size.isLandscape ? styles.pillSuccess : styles.pillNeutral
+            }`}
+          >
+            {size.isLandscape ? "Landscape" : "Portrait"}
+          </span>
+        </div>
+      </div>
+
+      <div className={styles.row}>
+        <span
+          className={`${styles.pill} ${size.isMobile ? styles.pillSuccess : styles.pillNeutral}`}
+        >
+          mobile: {String(size.isMobile)}
+        </span>
+        <span
+          className={`${styles.pill} ${size.isTablet ? styles.pillSuccess : styles.pillNeutral}`}
+        >
+          tablet: {String(size.isTablet)}
+        </span>
+        <span
+          className={`${styles.pill} ${size.isDesktop ? styles.pillSuccess : styles.pillNeutral}`}
+        >
+          desktop: {String(size.isDesktop)}
+        </span>
+      </div>
+
+      <div className={styles.row}>
+        <span className={`${styles.pill} ${styles.pillNeutral}`}>
+          above workspace: {String(size.isAbove("workspace"))}
+        </span>
+        <span className={`${styles.pill} ${styles.pillNeutral}`}>
+          below command: {String(size.isBelow("command"))}
+        </span>
+        <span className={`${styles.pill} ${styles.pillNeutral}`}>
+          in range: {String(size.isBetween("compact", "command"))}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/docs/components/home-page.tsx
+++ b/docs/components/home-page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { Pre } from "nextra/components";
 
 const EXPORTS: { path: string; note: string }[] = [
   { path: "react-rsc-kit", note: "Default entry - shared utilities and control-flow primitives." },
@@ -97,9 +98,9 @@ export function HomePage() {
           </Link>{" "}
           table below is the main contract to follow.
         </p>
-        <pre className="react-rsc-kit-code-snippet mt-3">
+        <Pre data-copy="" data-language="bash" className="react-rsc-kit-install-command mt-3">
           <code>npm install react-rsc-kit</code>
-        </pre>
+        </Pre>
         <div className="mt-4 grid gap-3 sm:grid-cols-3">
           {QUICK_ACTIONS.map((action) =>
             action.internal ? (

--- a/docs/components/site-logo.tsx
+++ b/docs/components/site-logo.tsx
@@ -1,8 +1,9 @@
 type SiteLogoProps = {
   compact?: boolean;
+  version?: string;
 };
 
-export function SiteLogo({ compact = false }: SiteLogoProps) {
+export function SiteLogo({ compact = false, version }: SiteLogoProps) {
   return (
     <span className="flex items-center gap-3 text-[var(--uk-text-primary)]">
       <span className="flex h-11 w-11 items-center justify-center rounded-lg border border-[var(--uk-border-subtle)] bg-[rgba(255,255,255,0.75)] shadow-[var(--uk-shadow-soft)] dark:bg-[rgba(255,255,255,0.05)]">
@@ -36,7 +37,12 @@ export function SiteLogo({ compact = false }: SiteLogoProps) {
         <span className="react-rsc-kit-muted-label">
           {compact ? "Docs" : "React utility library"}
         </span>
-        <span className="text-base font-semibold tracking-[-0.02em] sm:text-lg">react-rsc-kit</span>
+        <span className="flex items-center gap-2">
+          <span className="text-base font-semibold tracking-[-0.02em] sm:text-lg">
+            react-rsc-kit
+          </span>
+          {version ? <span className="react-rsc-kit-version-badge">v{version}</span> : null}
+        </span>
       </span>
     </span>
   );

--- a/docs/content/hooks/_meta.json
+++ b/docs/content/hooks/_meta.json
@@ -11,6 +11,12 @@
     "category": "Hooks",
     "subcategory": "UI"
   },
+  "useWindowSize": {
+    "title": "useWindowSize",
+    "order": 3,
+    "category": "Hooks",
+    "subcategory": "UI"
+  },
   "useToggle": "useToggle",
   "useControllableState": "useControllableState",
   "useDisclosure": "useDisclosure",

--- a/docs/content/hooks/useWindowSize.mdx
+++ b/docs/content/hooks/useWindowSize.mdx
@@ -1,0 +1,228 @@
+import { DemoFrame } from "../../components/demo-frame";
+import { UseWindowSizeDemo } from "../../components/demos/use-window-size-demo";
+
+# useWindowSize
+
+`useWindowSize` is an SSR-safe React 18+ hook for reading viewport dimensions and responsive layout state. It uses `useSyncExternalStore`, shared browser subscriptions, and typed breakpoint helpers so client components can react to size changes without duplicating `resize` listeners.
+
+<DemoFrame
+  title="Viewport state"
+  description="Resize the browser to see dimensions, orientation, breakpoints, and helper methods update from the shared window-size store."
+>
+  <UseWindowSizeDemo />
+</DemoFrame>
+
+## Why This Hook Exists
+
+Window size hooks are often written with `useEffect` and `useState`. That works for small demos, but it can cause repeated listeners, hydration surprises, and unnecessary renders in production applications. `useWindowSize` keeps browser subscriptions in one store and lets React read snapshots through `useSyncExternalStore`.
+
+The hook is built for both small projects and larger RSC applications:
+
+- Browser access is isolated to the subscription store.
+- Server rendering uses deterministic fallback snapshots.
+- Types and utilities can be imported from server-safe entrypoints.
+- Custom breakpoint objects infer their own key names.
+
+## Import
+
+```tsx
+import { useWindowSize } from "react-rsc-kit/client";
+```
+
+Types and utilities are safe to import outside client components:
+
+```tsx
+import type { UseWindowSizeOptions, UseWindowSizeReturn } from "react-rsc-kit";
+import { DEFAULT_WINDOW_SIZE_BREAKPOINTS } from "react-rsc-kit";
+```
+
+## Basic Usage
+
+```tsx
+"use client";
+
+import { useWindowSize } from "react-rsc-kit/client";
+
+export function ResponsiveToolbar() {
+  const size = useWindowSize();
+
+  return (
+    <header data-breakpoint={size.breakpoint ?? "base"}>
+      {size.isDesktop ? <DesktopActions /> : <CompactActions />}
+    </header>
+  );
+}
+```
+
+## Next.js App Router And RSC
+
+The hook itself must be used in a `"use client"` component.
+
+Server Components should not read viewport state directly because the server does not know the user's browser dimensions. If viewport state is required, pass stable server data to a Client Component and call `useWindowSize` there.
+
+```tsx
+// app/dashboard/page.tsx
+import { DashboardViewport } from "./dashboard-viewport";
+
+export default async function DashboardPage() {
+  const account = await getAccount();
+
+  return <DashboardViewport accountName={account.name} />;
+}
+```
+
+```tsx
+// app/dashboard/dashboard-viewport.tsx
+"use client";
+
+import { useWindowSize } from "react-rsc-kit/client";
+
+export function DashboardViewport({ accountName }: { accountName: string }) {
+  const { isDesktop } = useWindowSize();
+
+  return isDesktop ? <WideDashboard name={accountName} /> : <CompactDashboard name={accountName} />;
+}
+```
+
+Types and utilities from `window-size.types.ts` and `window-size.utils.ts` are safe to import in RSC files. The React hook and browser store are part of the client hook surface.
+
+## Custom Breakpoints
+
+```tsx
+"use client";
+
+import { useWindowSize } from "react-rsc-kit/client";
+
+const breakpoints = {
+  compact: 480,
+  workspace: 900,
+  command: 1200,
+} as const;
+
+export function Shell() {
+  const size = useWindowSize({ breakpoints });
+
+  size.breakpoint; // "compact" | "workspace" | "command" | null
+
+  return <main data-mode={size.isAbove("workspace") ? "expanded" : "compact"} />;
+}
+```
+
+Default breakpoints:
+
+```ts
+const DEFAULT_WINDOW_SIZE_BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+} as const;
+```
+
+## Debounce And Throttle
+
+```tsx
+const debouncedSize = useWindowSize({ debounceMs: 150 });
+const throttledSize = useWindowSize({ throttleMs: 100 });
+```
+
+Use debounce when expensive layout work should wait until resizing pauses. Use throttle when the UI should update during resizing at a bounded rate. If both options are provided, debounce takes precedence.
+
+## Visual Viewport
+
+```tsx
+const size = useWindowSize({
+  useVisualViewport: true,
+});
+```
+
+When `useVisualViewport` is enabled and `window.visualViewport` exists, `width` and `height` use visual viewport dimensions. `visualWidth` and `visualHeight` are returned separately in every mode. This is useful on mobile browsers where the visual viewport can change when browser chrome or on-screen keyboards appear.
+
+## Signature
+
+```ts
+const size = useWindowSize({
+  initialWidth,
+  initialHeight,
+  breakpoints,
+  debounceMs,
+  throttleMs,
+  enabled,
+  useVisualViewport,
+  round,
+});
+```
+
+## Returns
+
+| Key                  | Type                        | Description                                                             |
+| -------------------- | --------------------------- | ----------------------------------------------------------------------- |
+| `width`              | `number`                    | Active viewport width. Uses visual viewport width when enabled.         |
+| `height`             | `number`                    | Active viewport height. Uses visual viewport height when enabled.       |
+| `visualWidth`        | `number`                    | `window.visualViewport.width` when available, otherwise layout width.   |
+| `visualHeight`       | `number`                    | `window.visualViewport.height` when available, otherwise layout height. |
+| `devicePixelRatio`   | `number`                    | Current device pixel ratio, or `1` on the server.                       |
+| `isClient`           | `boolean`                   | Whether the snapshot came from a browser environment.                   |
+| `orientation`        | `"portrait" \| "landscape"` | Orientation derived from active width and height.                       |
+| `isPortrait`         | `boolean`                   | Whether `orientation` is `"portrait"`.                                  |
+| `isLandscape`        | `boolean`                   | Whether `orientation` is `"landscape"`.                                 |
+| `isMobile`           | `boolean`                   | `true` below the tablet threshold.                                      |
+| `isTablet`           | `boolean`                   | `true` between tablet and desktop thresholds.                           |
+| `isDesktop`          | `boolean`                   | `true` at or above the desktop threshold.                               |
+| `breakpoint`         | `keyof breakpoints \| null` | Largest matching breakpoint key.                                        |
+| `isAbove(key)`       | `(key) => boolean`          | `true` when `width >= breakpoints[key]`.                                |
+| `isBelow(key)`       | `(key) => boolean`          | `true` when `width < breakpoints[key]`.                                 |
+| `isBetween(min,max)` | `(min, max) => boolean`     | `true` when `width >= min` and `width < max`.                           |
+| `remountKey`         | `string`                    | Stable key based on breakpoint and orientation.                         |
+
+## Options
+
+| Name                | Type                     | Default             | Description                                                            |
+| ------------------- | ------------------------ | ------------------- | ---------------------------------------------------------------------- |
+| `initialWidth`      | `number`                 | `0`                 | Server and hydration fallback width.                                   |
+| `initialHeight`     | `number`                 | `0`                 | Server and hydration fallback height.                                  |
+| `breakpoints`       | `Record<string, number>` | default breakpoints | Named breakpoint map, ordered by numeric value.                        |
+| `debounceMs`        | `number`                 | `undefined`         | Debounces resize notifications by the supplied milliseconds.           |
+| `throttleMs`        | `number`                 | `undefined`         | Throttles resize notifications by the supplied milliseconds.           |
+| `enabled`           | `boolean`                | `true`              | Set to `false` to avoid subscribing to browser resize events.          |
+| `useVisualViewport` | `boolean`                | `false`             | Uses visual viewport dimensions for `width` and `height` when present. |
+| `round`             | `boolean`                | `false`             | Rounds fractional dimensions with `Math.round`.                        |
+
+## Testing Notes
+
+The hook's tests cover SSR fallback snapshots, initial browser values, resize and orientation updates, default and custom breakpoints, helper methods, disabled subscriptions, visual viewport mode, device pixel ratio, rounding, cleanup, debounce, and throttle behavior.
+
+## Enterprise Usage Notes
+
+- Prefer one shared breakpoint constant for a product area so inferred keys stay consistent.
+- Use `throttleMs` for live resize-driven UI and `debounceMs` for expensive recalculation.
+- Use `remountKey` only when a component truly needs to reset across orientation or breakpoint changes.
+- Keep Server Components responsible for data and Client Components responsible for viewport-driven layout decisions.
+
+## Small Project Usage Notes
+
+For small apps, the default call is usually enough:
+
+```tsx
+const { width, isMobile } = useWindowSize();
+```
+
+Add options only when the default behavior is not enough.
+
+## Common Pitfalls
+
+- Do not call `useWindowSize` in a Server Component.
+- Do not import the client hook into RSC files. Import only types and utilities there.
+- Do not assume the server knows the real viewport. `initialWidth` and `initialHeight` are fallbacks.
+- Do not use viewport state when CSS media queries alone can solve the layout.
+- Keep breakpoint objects stable when possible.
+
+## Architecture
+
+- `use-window-size.ts` contains the React hook.
+- `window-size-store.ts` owns browser subscriptions.
+- `window-size.types.ts` owns public types.
+- `window-size.utils.ts` owns breakpoint and viewport utility functions.
+- `index.ts` is the public export surface.
+- Tests live beside the feature for maintainability.

--- a/docs/global.d.ts
+++ b/docs/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/docs/next.config.mjs
+++ b/docs/next.config.mjs
@@ -43,7 +43,9 @@ const turbopackAlias = useSourceAliases
       ),
     }
   : undefined;
-const withNextra = nextra({});
+const withNextra = nextra({
+  defaultShowCopyCode: true,
+});
 
 export default withNextra({
   ...(useSourceAliases

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -121,22 +121,6 @@ body {
   background: rgba(255, 255, 255, 0.06);
 }
 
-.react-rsc-kit-code-snippet {
-  overflow-x: auto;
-  border-radius: 0.5rem;
-  border: 1px solid rgba(55, 53, 47, 0.15);
-  background: #1c1b19;
-  padding: 0.75rem 1rem;
-  font-size: 0.875rem;
-  line-height: 1.6;
-  color: #f0eeeb;
-}
-
-.dark .react-rsc-kit-code-snippet {
-  border-color: rgba(255, 255, 255, 0.12);
-  background: #121211;
-}
-
 .react-rsc-kit-step-index {
   display: flex;
   height: 1.5rem;
@@ -223,6 +207,11 @@ body {
 
 .react-rsc-kit-doc-nav-link code {
   font-size: 0.9em;
+}
+
+.react-rsc-kit-install-command code {
+  display: block;
+  padding-inline: 1rem 4.25rem;
 }
 
 .react-rsc-kit-doc-inline-link {

--- a/docs/styles/index.css
+++ b/docs/styles/index.css
@@ -248,6 +248,20 @@ body {
   background: rgb(var(--nextra-bg));
 }
 
+.react-rsc-kit-version-badge {
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  border: 1px solid var(--uk-border-subtle);
+  border-radius: 0.375rem;
+  background: rgba(255, 255, 255, 0.58);
+  padding: 0.12rem 0.4rem;
+  color: var(--uk-text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
 .react-rsc-kit-theme-toggle {
   border: 1px solid var(--uk-border-subtle);
   border-radius: 0.5rem;
@@ -492,6 +506,10 @@ body {
   border-color: var(--uk-border-subtle);
   background: rgba(255, 255, 255, 0.04);
   color: var(--uk-text-muted);
+}
+
+.dark .react-rsc-kit-version-badge {
+  background: rgba(255, 255, 255, 0.05);
 }
 
 .dark .react-rsc-kit-theme-toggle:hover {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.4.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-rsc-kit",
-      "version": "1.4.0",
+      "version": "1.7.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "React hooks and utility components with RSC-safe server/client entrypoints.",
   "author": "react-rsc-kit contributors",
   "license": "MIT",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from "./use-window-size";
 export * from "./useArray";
 export * from "./useAsync";
 export * from "./useAsyncFnc";

--- a/src/hooks/use-window-size/index.ts
+++ b/src/hooks/use-window-size/index.ts
@@ -1,0 +1,3 @@
+export { useWindowSize } from "./use-window-size";
+export type * from "./window-size.types";
+export * from "./window-size.utils";

--- a/src/hooks/use-window-size/use-window-size.test.ts
+++ b/src/hooks/use-window-size/use-window-size.test.ts
@@ -182,7 +182,7 @@ describe("useWindowSize", () => {
 
     act(() => {
       setViewport(900, 500);
-      window.dispatchEvent(new Event("orientationchange"));
+      dispatchResize();
     });
 
     expect(result.current.orientation).toBe("landscape");
@@ -314,13 +314,11 @@ describe("useWindowSize", () => {
     );
 
     expect(addWindowListener).toHaveBeenCalledWith("resize", expect.any(Function));
-    expect(addWindowListener).toHaveBeenCalledWith("orientationchange", expect.any(Function));
     expect(visualViewport.addEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
 
     unmount();
 
     expect(removeWindowListener).toHaveBeenCalledWith("resize", expect.any(Function));
-    expect(removeWindowListener).toHaveBeenCalledWith("orientationchange", expect.any(Function));
     expect(visualViewport.removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
   });
 

--- a/src/hooks/use-window-size/use-window-size.test.ts
+++ b/src/hooks/use-window-size/use-window-size.test.ts
@@ -1,0 +1,395 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { afterEach, beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { useWindowSize } from "./use-window-size";
+
+class MockVisualViewport extends EventTarget {
+  width: number;
+  height: number;
+  readonly offsetLeft = 0;
+  readonly offsetTop = 0;
+  readonly pageLeft = 0;
+  readonly pageTop = 0;
+  readonly scale = 1;
+  readonly addEventListener = vi.fn(
+    (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | AddEventListenerOptions,
+    ) => {
+      EventTarget.prototype.addEventListener.call(this, type, listener, options);
+    },
+  );
+  readonly removeEventListener = vi.fn(
+    (
+      type: string,
+      listener: EventListenerOrEventListenerObject | null,
+      options?: boolean | EventListenerOptions,
+    ) => {
+      EventTarget.prototype.removeEventListener.call(this, type, listener, options);
+    },
+  );
+
+  constructor(width: number, height: number) {
+    super();
+    this.width = width;
+    this.height = height;
+  }
+}
+
+const originalGlobalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalInnerWidthDescriptor = Object.getOwnPropertyDescriptor(window, "innerWidth");
+const originalInnerHeightDescriptor = Object.getOwnPropertyDescriptor(window, "innerHeight");
+const originalDevicePixelRatioDescriptor = Object.getOwnPropertyDescriptor(
+  window,
+  "devicePixelRatio",
+);
+const originalVisualViewportDescriptor = Object.getOwnPropertyDescriptor(window, "visualViewport");
+
+function restoreGlobalWindow(): void {
+  if (originalGlobalWindowDescriptor) {
+    Object.defineProperty(globalThis, "window", originalGlobalWindowDescriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, "window");
+}
+
+function restoreWindowProperty(
+  key: "innerWidth" | "innerHeight" | "devicePixelRatio" | "visualViewport",
+  descriptor: PropertyDescriptor | undefined,
+): void {
+  if (descriptor) {
+    Object.defineProperty(window, key, descriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(window, key);
+}
+
+function setWindowNumberProperty(
+  key: "innerWidth" | "innerHeight" | "devicePixelRatio",
+  value: number,
+): void {
+  Object.defineProperty(window, key, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function setViewport(width: number, height: number, devicePixelRatio = 1): void {
+  setWindowNumberProperty("innerWidth", width);
+  setWindowNumberProperty("innerHeight", height);
+  setWindowNumberProperty("devicePixelRatio", devicePixelRatio);
+}
+
+function setVisualViewport(visualViewport: MockVisualViewport | undefined): void {
+  Object.defineProperty(window, "visualViewport", {
+    configurable: true,
+    writable: true,
+    value: visualViewport,
+  });
+}
+
+function dispatchResize(): void {
+  window.dispatchEvent(new Event("resize"));
+}
+
+describe("useWindowSize", () => {
+  beforeEach(() => {
+    setViewport(1024, 768);
+    setVisualViewport(undefined);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    restoreGlobalWindow();
+
+    if (typeof window !== "undefined") {
+      restoreWindowProperty("innerWidth", originalInnerWidthDescriptor);
+      restoreWindowProperty("innerHeight", originalInnerHeightDescriptor);
+      restoreWindowProperty("devicePixelRatio", originalDevicePixelRatioDescriptor);
+      restoreWindowProperty("visualViewport", originalVisualViewportDescriptor);
+    }
+  });
+
+  it("uses the SSR snapshot when window is unavailable", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: undefined,
+    });
+
+    function ServerRenderedWindowSize() {
+      const size = useWindowSize({
+        initialWidth: 320,
+        initialHeight: 480,
+      });
+
+      return createElement(
+        "span",
+        null,
+        `${size.width}:${size.height}:${String(size.isClient)}:${size.orientation}`,
+      );
+    }
+
+    try {
+      expect(renderToString(createElement(ServerRenderedWindowSize))).toContain(
+        "<span>320:480:false:portrait</span>",
+      );
+    } finally {
+      restoreGlobalWindow();
+    }
+  });
+
+  it("returns the initial client value", () => {
+    setViewport(1280, 720, 2);
+
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.width).toBe(1280);
+    expect(result.current.height).toBe(720);
+    expect(result.current.visualWidth).toBe(1280);
+    expect(result.current.visualHeight).toBe(720);
+    expect(result.current.devicePixelRatio).toBe(2);
+    expect(result.current.isClient).toBe(true);
+  });
+
+  it("updates width and height after resize events", () => {
+    setViewport(800, 600);
+    const { result } = renderHook(() => useWindowSize());
+
+    act(() => {
+      setViewport(900, 650);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(900);
+    expect(result.current.height).toBe(650);
+  });
+
+  it("detects orientation from the active viewport dimensions", () => {
+    setViewport(500, 900);
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.orientation).toBe("portrait");
+    expect(result.current.isPortrait).toBe(true);
+    expect(result.current.isLandscape).toBe(false);
+
+    act(() => {
+      setViewport(900, 500);
+      window.dispatchEvent(new Event("orientationchange"));
+    });
+
+    expect(result.current.orientation).toBe("landscape");
+    expect(result.current.isPortrait).toBe(false);
+    expect(result.current.isLandscape).toBe(true);
+  });
+
+  it("detects the active default breakpoint and device flags", () => {
+    setViewport(1100, 700);
+
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.breakpoint).toBe("lg");
+    expect(result.current.isMobile).toBe(false);
+    expect(result.current.isTablet).toBe(false);
+    expect(result.current.isDesktop).toBe(true);
+  });
+
+  it("supports custom breakpoint inference and runtime behavior", () => {
+    const customBreakpoints = {
+      compact: 360,
+      comfortable: 900,
+      wide: 1200,
+    } as const;
+    setViewport(950, 700);
+
+    const { result } = renderHook(() =>
+      useWindowSize({
+        breakpoints: customBreakpoints,
+      }),
+    );
+
+    expectTypeOf(result.current.breakpoint).toEqualTypeOf<
+      "compact" | "comfortable" | "wide" | null
+    >();
+    expect(result.current.breakpoint).toBe("comfortable");
+    expect(result.current.isAbove("comfortable")).toBe(true);
+    expect(result.current.isBelow("wide")).toBe(true);
+  });
+
+  it("resolves isAbove, isBelow, and isBetween helpers", () => {
+    setViewport(800, 700);
+
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.isAbove("sm")).toBe(true);
+    expect(result.current.isAbove("lg")).toBe(false);
+    expect(result.current.isBelow("lg")).toBe(true);
+    expect(result.current.isBetween("sm", "lg")).toBe(true);
+    expect(result.current.isBetween("lg", "xl")).toBe(false);
+  });
+
+  it("does not subscribe to updates when disabled", () => {
+    setViewport(700, 600);
+    const { result } = renderHook(() =>
+      useWindowSize({
+        enabled: false,
+      }),
+    );
+
+    act(() => {
+      setViewport(1000, 700);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(700);
+    expect(result.current.height).toBe(600);
+  });
+
+  it("uses visual viewport dimensions when enabled and available", () => {
+    setViewport(1200, 900);
+    const visualViewport = new MockVisualViewport(375, 667);
+    setVisualViewport(visualViewport);
+    const { result } = renderHook(() =>
+      useWindowSize({
+        useVisualViewport: true,
+      }),
+    );
+
+    expect(result.current.width).toBe(375);
+    expect(result.current.height).toBe(667);
+    expect(result.current.visualWidth).toBe(375);
+    expect(result.current.visualHeight).toBe(667);
+
+    act(() => {
+      visualViewport.width = 390;
+      visualViewport.height = 700;
+      visualViewport.dispatchEvent(new Event("resize"));
+    });
+
+    expect(result.current.width).toBe(390);
+    expect(result.current.height).toBe(700);
+  });
+
+  it("returns devicePixelRatio", () => {
+    setViewport(1024, 768, 2.5);
+
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current.devicePixelRatio).toBe(2.5);
+  });
+
+  it("rounds fractional viewport values when requested", () => {
+    setViewport(100.6, 200.2);
+    const visualViewport = new MockVisualViewport(300.4, 400.8);
+    setVisualViewport(visualViewport);
+
+    const { result } = renderHook(() =>
+      useWindowSize({
+        round: true,
+      }),
+    );
+
+    expect(result.current.width).toBe(101);
+    expect(result.current.height).toBe(200);
+    expect(result.current.visualWidth).toBe(300);
+    expect(result.current.visualHeight).toBe(401);
+  });
+
+  it("cleans up event listeners on unmount", () => {
+    const addWindowListener = vi.spyOn(window, "addEventListener");
+    const removeWindowListener = vi.spyOn(window, "removeEventListener");
+    const visualViewport = new MockVisualViewport(800, 600);
+    setVisualViewport(visualViewport);
+    const { unmount } = renderHook(() =>
+      useWindowSize({
+        useVisualViewport: true,
+      }),
+    );
+
+    expect(addWindowListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(addWindowListener).toHaveBeenCalledWith("orientationchange", expect.any(Function));
+    expect(visualViewport.addEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+
+    unmount();
+
+    expect(removeWindowListener).toHaveBeenCalledWith("resize", expect.any(Function));
+    expect(removeWindowListener).toHaveBeenCalledWith("orientationchange", expect.any(Function));
+    expect(visualViewport.removeEventListener).toHaveBeenCalledWith("resize", expect.any(Function));
+  });
+
+  it("debounces resize notifications", () => {
+    vi.useFakeTimers();
+    setViewport(500, 400);
+    const { result } = renderHook(() =>
+      useWindowSize({
+        debounceMs: 100,
+      }),
+    );
+
+    act(() => {
+      setViewport(600, 450);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(500);
+
+    act(() => {
+      vi.advanceTimersByTime(99);
+    });
+
+    expect(result.current.width).toBe(500);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.width).toBe(600);
+    expect(result.current.height).toBe(450);
+  });
+
+  it("throttles resize notifications", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    setViewport(500, 400);
+    const { result } = renderHook(() =>
+      useWindowSize({
+        throttleMs: 100,
+      }),
+    );
+
+    act(() => {
+      setViewport(600, 450);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(600);
+
+    act(() => {
+      vi.advanceTimersByTime(50);
+      setViewport(700, 500);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(600);
+
+    act(() => {
+      vi.advanceTimersByTime(49);
+    });
+
+    expect(result.current.width).toBe(600);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+
+    expect(result.current.width).toBe(700);
+    expect(result.current.height).toBe(500);
+  });
+});

--- a/src/hooks/use-window-size/use-window-size.test.ts
+++ b/src/hooks/use-window-size/use-window-size.test.ts
@@ -223,6 +223,25 @@ describe("useWindowSize", () => {
     expect(result.current.isBelow("wide")).toBe(true);
   });
 
+  it("derives device flags from unnamed custom breakpoints", () => {
+    const customBreakpoints = {
+      small: 500,
+      large: 1000,
+    } as const;
+    setViewport(600, 700);
+
+    const { result } = renderHook(() =>
+      useWindowSize({
+        breakpoints: customBreakpoints,
+      }),
+    );
+
+    expect(result.current.breakpoint).toBe("small");
+    expect(result.current.isMobile).toBe(false);
+    expect(result.current.isTablet).toBe(true);
+    expect(result.current.isDesktop).toBe(false);
+  });
+
   it("resolves isAbove, isBelow, and isBetween helpers", () => {
     setViewport(800, 700);
 

--- a/src/hooks/use-window-size/use-window-size.test.ts
+++ b/src/hooks/use-window-size/use-window-size.test.ts
@@ -271,6 +271,58 @@ describe("useWindowSize", () => {
     expect(result.current.height).toBe(600);
   });
 
+  it("captures a fresh disabled snapshot after being re-enabled", () => {
+    setViewport(700, 600);
+    const { result, rerender } = renderHook(
+      ({ enabled }: { enabled: boolean }) =>
+        useWindowSize({
+          enabled,
+        }),
+      {
+        initialProps: {
+          enabled: false,
+        },
+      },
+    );
+
+    expect(result.current.width).toBe(700);
+    expect(result.current.height).toBe(600);
+
+    act(() => {
+      setViewport(900, 650);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(700);
+    expect(result.current.height).toBe(600);
+
+    rerender({ enabled: true });
+
+    expect(result.current.width).toBe(900);
+    expect(result.current.height).toBe(650);
+
+    act(() => {
+      setViewport(1100, 720);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(1100);
+    expect(result.current.height).toBe(720);
+
+    rerender({ enabled: false });
+
+    expect(result.current.width).toBe(1100);
+    expect(result.current.height).toBe(720);
+
+    act(() => {
+      setViewport(1200, 800);
+      dispatchResize();
+    });
+
+    expect(result.current.width).toBe(1100);
+    expect(result.current.height).toBe(720);
+  });
+
   it("uses visual viewport dimensions when enabled and available", () => {
     setViewport(1200, 900);
     const visualViewport = new MockVisualViewport(375, 667);

--- a/src/hooks/use-window-size/use-window-size.ts
+++ b/src/hooks/use-window-size/use-window-size.ts
@@ -57,10 +57,6 @@ export function useWindowSize<
     [initialHeight, initialWidth],
   );
 
-  if (enabled && disabledSnapshotRef.current !== null) {
-    disabledSnapshotRef.current = null;
-  }
-
   const getSnapshot = useCallback((): WindowSizeStoreSnapshot => {
     if (!enabled) {
       disabledSnapshotRef.current ??= getWindowSizeStoreSnapshot();

--- a/src/hooks/use-window-size/use-window-size.ts
+++ b/src/hooks/use-window-size/use-window-size.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 
 import {
   UseWindowSizeOptions,
@@ -56,6 +56,12 @@ export function useWindowSize<
       }),
     [initialHeight, initialWidth],
   );
+
+  useEffect(() => {
+    if (enabled) {
+      disabledSnapshotRef.current = null;
+    }
+  }, [enabled]);
 
   const getSnapshot = useCallback((): WindowSizeStoreSnapshot => {
     if (!enabled) {

--- a/src/hooks/use-window-size/use-window-size.ts
+++ b/src/hooks/use-window-size/use-window-size.ts
@@ -42,7 +42,10 @@ export function useWindowSize<
     useVisualViewport = false,
     round = false,
   } = options;
-  const breakpointSignature = getWindowSizeBreakpointSignature(breakpoints);
+  const breakpointSignature = useMemo(
+    () => getWindowSizeBreakpointSignature(breakpoints),
+    [breakpoints],
+  );
   const stableBreakpoints = useMemo(() => breakpoints, [breakpointSignature]);
   const disabledSnapshotRef = useRef<WindowSizeStoreSnapshot | null>(null);
   const serverSnapshot = useMemo(

--- a/src/hooks/use-window-size/use-window-size.ts
+++ b/src/hooks/use-window-size/use-window-size.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+
+import {
+  UseWindowSizeOptions,
+  UseWindowSizeReturn,
+  WindowSizeBreakpoints,
+  WindowSizeStoreSnapshot,
+} from "./window-size.types";
+import {
+  createWindowSizeSnapshot,
+  DEFAULT_WINDOW_SIZE_BREAKPOINTS,
+  getWindowSizeBreakpoint,
+  getWindowSizeBreakpointSignature,
+  getWindowSizeDeviceFlags,
+  getWindowSizeOrientation,
+  getWindowSizeRemountKey,
+  isAboveWindowSizeBreakpoint,
+  isBelowWindowSizeBreakpoint,
+  isBetweenWindowSizeBreakpoints,
+} from "./window-size.utils";
+import {
+  createWindowSizeStoreServerSnapshot,
+  getWindowSizeStoreSnapshot,
+  subscribeToWindowSizeStore,
+} from "./window-size-store";
+
+/**
+ * Subscribe to viewport size through React's external store contract.
+ */
+export function useWindowSize<
+  TBreakpoints extends WindowSizeBreakpoints = typeof DEFAULT_WINDOW_SIZE_BREAKPOINTS,
+>(options: UseWindowSizeOptions<TBreakpoints> = {}): UseWindowSizeReturn<TBreakpoints> {
+  const {
+    initialWidth,
+    initialHeight,
+    breakpoints = DEFAULT_WINDOW_SIZE_BREAKPOINTS as unknown as TBreakpoints,
+    debounceMs,
+    throttleMs,
+    enabled = true,
+    useVisualViewport = false,
+    round = false,
+  } = options;
+  const breakpointSignature = getWindowSizeBreakpointSignature(breakpoints);
+  const stableBreakpoints = useMemo(() => breakpoints, [breakpointSignature]);
+  const disabledSnapshotRef = useRef<WindowSizeStoreSnapshot | null>(null);
+  const serverSnapshot = useMemo(
+    () =>
+      createWindowSizeStoreServerSnapshot({
+        initialWidth,
+        initialHeight,
+      }),
+    [initialHeight, initialWidth],
+  );
+
+  if (enabled && disabledSnapshotRef.current !== null) {
+    disabledSnapshotRef.current = null;
+  }
+
+  const getSnapshot = useCallback((): WindowSizeStoreSnapshot => {
+    if (!enabled) {
+      disabledSnapshotRef.current ??= getWindowSizeStoreSnapshot();
+      return disabledSnapshotRef.current;
+    }
+
+    return getWindowSizeStoreSnapshot();
+  }, [enabled]);
+
+  const getServerSnapshot = useCallback(() => serverSnapshot, [serverSnapshot]);
+
+  const subscribe = useCallback(
+    (listener: () => void) =>
+      subscribeToWindowSizeStore(listener, {
+        debounceMs,
+        throttleMs,
+        enabled,
+        useVisualViewport,
+      }),
+    [debounceMs, enabled, throttleMs, useVisualViewport],
+  );
+
+  const storeSnapshot = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  const snapshot = useMemo(
+    () =>
+      createWindowSizeSnapshot(storeSnapshot, {
+        useVisualViewport,
+        round,
+      }),
+    [round, storeSnapshot, useVisualViewport],
+  );
+
+  return useMemo<UseWindowSizeReturn<TBreakpoints>>(() => {
+    const orientation = getWindowSizeOrientation(snapshot.width, snapshot.height);
+    const breakpoint = getWindowSizeBreakpoint(snapshot.width, stableBreakpoints);
+    const deviceFlags = getWindowSizeDeviceFlags(snapshot.width, stableBreakpoints);
+
+    return {
+      ...snapshot,
+      orientation,
+      isPortrait: orientation === "portrait",
+      isLandscape: orientation === "landscape",
+      ...deviceFlags,
+      breakpoint,
+      isAbove: (key) => isAboveWindowSizeBreakpoint(snapshot.width, stableBreakpoints, key),
+      isBelow: (key) => isBelowWindowSizeBreakpoint(snapshot.width, stableBreakpoints, key),
+      isBetween: (min, max) =>
+        isBetweenWindowSizeBreakpoints(snapshot.width, stableBreakpoints, min, max),
+      remountKey: getWindowSizeRemountKey(breakpoint, orientation),
+    };
+  }, [snapshot, stableBreakpoints]);
+}

--- a/src/hooks/use-window-size/window-size-store.ts
+++ b/src/hooks/use-window-size/window-size-store.ts
@@ -140,13 +140,11 @@ function ensureWindowListeners(): void {
 
   if (shouldListenToWindow && !listeningToWindow) {
     window.addEventListener("resize", handleWindowSizeChange);
-    window.addEventListener("orientationchange", handleWindowSizeChange);
     listeningToWindow = true;
   }
 
   if (!shouldListenToWindow && listeningToWindow) {
     window.removeEventListener("resize", handleWindowSizeChange);
-    window.removeEventListener("orientationchange", handleWindowSizeChange);
     listeningToWindow = false;
   }
 

--- a/src/hooks/use-window-size/window-size-store.ts
+++ b/src/hooks/use-window-size/window-size-store.ts
@@ -1,0 +1,195 @@
+import { WindowSizeStoreSnapshot } from "./window-size.types";
+import {
+  areWindowSizeStoreSnapshotsEqual,
+  createInitialWindowSizeStoreSnapshot,
+  CreateWindowSizeStoreSnapshotOptions,
+  isWindowSizeBrowser,
+  readWindowSizeStoreSnapshot,
+} from "./window-size.utils";
+
+interface WindowSizeSubscriptionOptions {
+  debounceMs?: number;
+  throttleMs?: number;
+  enabled?: boolean;
+  useVisualViewport?: boolean;
+}
+
+interface WindowSizeSubscription {
+  listener: () => void;
+  debounceMs: number;
+  throttleMs: number;
+  useVisualViewport: boolean;
+  timeoutId: ReturnType<typeof setTimeout> | null;
+  lastNotifiedAt: number | null;
+  disposed: boolean;
+}
+
+const subscriptions = new Set<WindowSizeSubscription>();
+
+let currentSnapshot: WindowSizeStoreSnapshot | null = null;
+let listeningToWindow = false;
+let visualViewportTarget: VisualViewport | null = null;
+
+function normalizeDelay(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function hasVisualViewportSubscribers(): boolean {
+  return Array.from(subscriptions).some((subscription) => subscription.useVisualViewport);
+}
+
+function clearSubscriptionTimer(subscription: WindowSizeSubscription): void {
+  if (subscription.timeoutId === null) {
+    return;
+  }
+
+  clearTimeout(subscription.timeoutId);
+  subscription.timeoutId = null;
+}
+
+function notifySubscription(subscription: WindowSizeSubscription): void {
+  if (subscription.disposed) {
+    return;
+  }
+
+  subscription.lastNotifiedAt = Date.now();
+  subscription.listener();
+}
+
+function scheduleSubscriptionNotification(subscription: WindowSizeSubscription): void {
+  if (subscription.debounceMs > 0) {
+    clearSubscriptionTimer(subscription);
+    subscription.timeoutId = setTimeout(() => {
+      subscription.timeoutId = null;
+      notifySubscription(subscription);
+    }, subscription.debounceMs);
+    return;
+  }
+
+  if (subscription.throttleMs > 0) {
+    const now = Date.now();
+    const lastNotifiedAt = subscription.lastNotifiedAt;
+
+    if (lastNotifiedAt === null || now - lastNotifiedAt >= subscription.throttleMs) {
+      clearSubscriptionTimer(subscription);
+      notifySubscription(subscription);
+      return;
+    }
+
+    if (subscription.timeoutId === null) {
+      subscription.timeoutId = setTimeout(
+        () => {
+          subscription.timeoutId = null;
+          notifySubscription(subscription);
+        },
+        subscription.throttleMs - (now - lastNotifiedAt),
+      );
+    }
+    return;
+  }
+
+  notifySubscription(subscription);
+}
+
+function handleWindowSizeChange(): void {
+  const previousSnapshot = currentSnapshot;
+  const nextSnapshot = getWindowSizeStoreSnapshot();
+
+  if (previousSnapshot !== null && Object.is(previousSnapshot, nextSnapshot)) {
+    return;
+  }
+
+  subscriptions.forEach((subscription) => {
+    scheduleSubscriptionNotification(subscription);
+  });
+}
+
+function ensureVisualViewportListener(): void {
+  if (!isWindowSizeBrowser()) {
+    return;
+  }
+
+  const nextTarget =
+    subscriptions.size > 0 && hasVisualViewportSubscribers()
+      ? (window.visualViewport ?? null)
+      : null;
+
+  if (visualViewportTarget !== null && visualViewportTarget !== nextTarget) {
+    visualViewportTarget.removeEventListener("resize", handleWindowSizeChange);
+    visualViewportTarget = null;
+  }
+
+  if (visualViewportTarget === null && nextTarget !== null) {
+    nextTarget.addEventListener("resize", handleWindowSizeChange);
+    visualViewportTarget = nextTarget;
+  }
+}
+
+function ensureWindowListeners(): void {
+  if (!isWindowSizeBrowser()) {
+    return;
+  }
+
+  const shouldListenToWindow = subscriptions.size > 0;
+
+  if (shouldListenToWindow && !listeningToWindow) {
+    window.addEventListener("resize", handleWindowSizeChange);
+    window.addEventListener("orientationchange", handleWindowSizeChange);
+    listeningToWindow = true;
+  }
+
+  if (!shouldListenToWindow && listeningToWindow) {
+    window.removeEventListener("resize", handleWindowSizeChange);
+    window.removeEventListener("orientationchange", handleWindowSizeChange);
+    listeningToWindow = false;
+  }
+
+  ensureVisualViewportListener();
+}
+
+export function createWindowSizeStoreServerSnapshot(
+  options: CreateWindowSizeStoreSnapshotOptions = {},
+): WindowSizeStoreSnapshot {
+  return createInitialWindowSizeStoreSnapshot(options);
+}
+
+export function getWindowSizeStoreSnapshot(): WindowSizeStoreSnapshot {
+  const nextSnapshot = readWindowSizeStoreSnapshot();
+
+  if (currentSnapshot !== null && areWindowSizeStoreSnapshotsEqual(currentSnapshot, nextSnapshot)) {
+    return currentSnapshot;
+  }
+
+  currentSnapshot = nextSnapshot;
+  return currentSnapshot;
+}
+
+export function subscribeToWindowSizeStore(
+  listener: () => void,
+  options: WindowSizeSubscriptionOptions = {},
+): () => void {
+  if (options.enabled === false || !isWindowSizeBrowser()) {
+    return () => {};
+  }
+
+  const debounceMs = normalizeDelay(options.debounceMs);
+  const subscription: WindowSizeSubscription = {
+    listener,
+    debounceMs,
+    throttleMs: debounceMs > 0 ? 0 : normalizeDelay(options.throttleMs),
+    useVisualViewport: options.useVisualViewport === true,
+    timeoutId: null,
+    lastNotifiedAt: null,
+    disposed: false,
+  };
+
+  subscriptions.add(subscription);
+  ensureWindowListeners();
+
+  return () => {
+    subscription.disposed = true;
+    clearSubscriptionTimer(subscription);
+    subscriptions.delete(subscription);
+    ensureWindowListeners();
+  };
+}

--- a/src/hooks/use-window-size/window-size-store.ts
+++ b/src/hooks/use-window-size/window-size-store.ts
@@ -35,7 +35,13 @@ function normalizeDelay(value: number | undefined): number {
 }
 
 function hasVisualViewportSubscribers(): boolean {
-  return Array.from(subscriptions).some((subscription) => subscription.useVisualViewport);
+  for (const subscription of subscriptions) {
+    if (subscription.useVisualViewport) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function clearSubscriptionTimer(subscription: WindowSizeSubscription): void {

--- a/src/hooks/use-window-size/window-size.types.ts
+++ b/src/hooks/use-window-size/window-size.types.ts
@@ -1,0 +1,58 @@
+export type WindowSizeBreakpoints = Record<string, number>;
+
+export type WindowSizeBreakpointKey<TBreakpoints extends WindowSizeBreakpoints> = Extract<
+  keyof TBreakpoints,
+  string
+>;
+
+export type WindowSizeOrientation = "portrait" | "landscape";
+
+export interface WindowSizeStoreSnapshot {
+  layoutWidth: number;
+  layoutHeight: number;
+  visualWidth: number;
+  visualHeight: number;
+  devicePixelRatio: number;
+  isClient: boolean;
+}
+
+export interface WindowSizeSnapshot {
+  width: number;
+  height: number;
+  visualWidth: number;
+  visualHeight: number;
+  devicePixelRatio: number;
+  isClient: boolean;
+}
+
+export interface UseWindowSizeOptions<
+  TBreakpoints extends WindowSizeBreakpoints = WindowSizeBreakpoints,
+> {
+  initialWidth?: number;
+  initialHeight?: number;
+  breakpoints?: TBreakpoints;
+  debounceMs?: number;
+  throttleMs?: number;
+  enabled?: boolean;
+  useVisualViewport?: boolean;
+  round?: boolean;
+}
+
+export interface UseWindowSizeReturn<
+  TBreakpoints extends WindowSizeBreakpoints,
+> extends WindowSizeSnapshot {
+  orientation: WindowSizeOrientation;
+  isPortrait: boolean;
+  isLandscape: boolean;
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+  breakpoint: WindowSizeBreakpointKey<TBreakpoints> | null;
+  isAbove: (key: WindowSizeBreakpointKey<TBreakpoints>) => boolean;
+  isBelow: (key: WindowSizeBreakpointKey<TBreakpoints>) => boolean;
+  isBetween: (
+    min: WindowSizeBreakpointKey<TBreakpoints>,
+    max: WindowSizeBreakpointKey<TBreakpoints>,
+  ) => boolean;
+  remountKey: string;
+}

--- a/src/hooks/use-window-size/window-size.utils.ts
+++ b/src/hooks/use-window-size/window-size.utils.ts
@@ -171,6 +171,28 @@ function getNamedBreakpointValue(breakpoints: WindowSizeBreakpoints, key: string
   return Number.isFinite(value) ? value : null;
 }
 
+function getDerivedWindowSizeDeviceFlagBreakpoints(
+  breakpoints: WindowSizeBreakpoints,
+): { tabletMin: number; desktopMin: number } | null {
+  const breakpointValues = getWindowSizeBreakpointEntries(breakpoints).map(([, value]) => value);
+
+  if (breakpointValues.length >= 3) {
+    return {
+      tabletMin: breakpointValues[1],
+      desktopMin: breakpointValues[2],
+    };
+  }
+
+  if (breakpointValues.length >= 2) {
+    return {
+      tabletMin: breakpointValues[0],
+      desktopMin: breakpointValues[1],
+    };
+  }
+
+  return null;
+}
+
 export function isAboveWindowSizeBreakpoint<TBreakpoints extends WindowSizeBreakpoints>(
   width: number,
   breakpoints: TBreakpoints,
@@ -207,17 +229,25 @@ export function getWindowSizeDeviceFlags(
   width: number,
   breakpoints: WindowSizeBreakpoints = DEFAULT_WINDOW_SIZE_BREAKPOINTS,
 ): WindowSizeDeviceFlags {
+  const derivedBreakpoints = getDerivedWindowSizeDeviceFlagBreakpoints(breakpoints);
   const tabletMin =
     getNamedBreakpointValue(breakpoints, "md") ??
     getNamedBreakpointValue(breakpoints, "tablet") ??
+    derivedBreakpoints?.tabletMin ??
     DEFAULT_WINDOW_SIZE_BREAKPOINTS.md;
   const desktopMin =
     getNamedBreakpointValue(breakpoints, "lg") ??
     getNamedBreakpointValue(breakpoints, "desktop") ??
+    derivedBreakpoints?.desktopMin ??
     DEFAULT_WINDOW_SIZE_BREAKPOINTS.lg;
-  const resolvedTabletMin = tabletMin < desktopMin ? tabletMin : DEFAULT_WINDOW_SIZE_BREAKPOINTS.md;
+  const resolvedTabletMin =
+    tabletMin < desktopMin
+      ? tabletMin
+      : (derivedBreakpoints?.tabletMin ?? DEFAULT_WINDOW_SIZE_BREAKPOINTS.md);
   const resolvedDesktopMin =
-    tabletMin < desktopMin ? desktopMin : DEFAULT_WINDOW_SIZE_BREAKPOINTS.lg;
+    tabletMin < desktopMin
+      ? desktopMin
+      : (derivedBreakpoints?.desktopMin ?? DEFAULT_WINDOW_SIZE_BREAKPOINTS.lg);
 
   return {
     isMobile: width < resolvedTabletMin,

--- a/src/hooks/use-window-size/window-size.utils.ts
+++ b/src/hooks/use-window-size/window-size.utils.ts
@@ -134,7 +134,11 @@ export function getWindowSizeBreakpointEntries<TBreakpoints extends WindowSizeBr
 }
 
 export function getWindowSizeBreakpointSignature(breakpoints: WindowSizeBreakpoints): string {
-  return JSON.stringify(Object.entries(breakpoints));
+  return JSON.stringify(
+    Object.entries(breakpoints).sort(([previousKey], [nextKey]) =>
+      previousKey.localeCompare(nextKey),
+    ),
+  );
 }
 
 export function getWindowSizeBreakpoint<TBreakpoints extends WindowSizeBreakpoints>(

--- a/src/hooks/use-window-size/window-size.utils.ts
+++ b/src/hooks/use-window-size/window-size.utils.ts
@@ -1,0 +1,230 @@
+import {
+  WindowSizeBreakpointKey,
+  WindowSizeBreakpoints,
+  WindowSizeOrientation,
+  WindowSizeSnapshot,
+  WindowSizeStoreSnapshot,
+} from "./window-size.types";
+
+export const DEFAULT_WINDOW_SIZE_BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  "2xl": 1536,
+} as const;
+
+type WindowSizeBreakpointEntry<TBreakpoints extends WindowSizeBreakpoints> = [
+  WindowSizeBreakpointKey<TBreakpoints>,
+  number,
+];
+
+export interface CreateWindowSizeSnapshotOptions {
+  useVisualViewport?: boolean;
+  round?: boolean;
+}
+
+export interface CreateWindowSizeStoreSnapshotOptions {
+  initialWidth?: number;
+  initialHeight?: number;
+}
+
+export interface WindowSizeDeviceFlags {
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+}
+
+export function isWindowSizeBrowser(): boolean {
+  return typeof window !== "undefined";
+}
+
+function sanitizeDimension(value: number | undefined, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function sanitizeDevicePixelRatio(value: number | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 1;
+}
+
+function maybeRound(value: number, round: boolean | undefined): number {
+  return round ? Math.round(value) : value;
+}
+
+export function createInitialWindowSizeStoreSnapshot(
+  options: CreateWindowSizeStoreSnapshotOptions = {},
+): WindowSizeStoreSnapshot {
+  const width = sanitizeDimension(options.initialWidth);
+  const height = sanitizeDimension(options.initialHeight);
+
+  return {
+    layoutWidth: width,
+    layoutHeight: height,
+    visualWidth: width,
+    visualHeight: height,
+    devicePixelRatio: 1,
+    isClient: false,
+  };
+}
+
+export function readWindowSizeStoreSnapshot(): WindowSizeStoreSnapshot {
+  if (!isWindowSizeBrowser()) {
+    return createInitialWindowSizeStoreSnapshot();
+  }
+
+  const layoutWidth = sanitizeDimension(window.innerWidth);
+  const layoutHeight = sanitizeDimension(window.innerHeight);
+  const visualViewport = window.visualViewport;
+  const visualWidth = sanitizeDimension(visualViewport?.width, layoutWidth);
+  const visualHeight = sanitizeDimension(visualViewport?.height, layoutHeight);
+
+  return {
+    layoutWidth,
+    layoutHeight,
+    visualWidth,
+    visualHeight,
+    devicePixelRatio: sanitizeDevicePixelRatio(window.devicePixelRatio),
+    isClient: true,
+  };
+}
+
+export function areWindowSizeStoreSnapshotsEqual(
+  previousSnapshot: WindowSizeStoreSnapshot,
+  nextSnapshot: WindowSizeStoreSnapshot,
+): boolean {
+  return (
+    Object.is(previousSnapshot.layoutWidth, nextSnapshot.layoutWidth) &&
+    Object.is(previousSnapshot.layoutHeight, nextSnapshot.layoutHeight) &&
+    Object.is(previousSnapshot.visualWidth, nextSnapshot.visualWidth) &&
+    Object.is(previousSnapshot.visualHeight, nextSnapshot.visualHeight) &&
+    Object.is(previousSnapshot.devicePixelRatio, nextSnapshot.devicePixelRatio) &&
+    Object.is(previousSnapshot.isClient, nextSnapshot.isClient)
+  );
+}
+
+export function createWindowSizeSnapshot(
+  storeSnapshot: WindowSizeStoreSnapshot,
+  options: CreateWindowSizeSnapshotOptions = {},
+): WindowSizeSnapshot {
+  const width = options.useVisualViewport ? storeSnapshot.visualWidth : storeSnapshot.layoutWidth;
+  const height = options.useVisualViewport
+    ? storeSnapshot.visualHeight
+    : storeSnapshot.layoutHeight;
+
+  return {
+    width: maybeRound(width, options.round),
+    height: maybeRound(height, options.round),
+    visualWidth: maybeRound(storeSnapshot.visualWidth, options.round),
+    visualHeight: maybeRound(storeSnapshot.visualHeight, options.round),
+    devicePixelRatio: storeSnapshot.devicePixelRatio,
+    isClient: storeSnapshot.isClient,
+  };
+}
+
+export function getWindowSizeOrientation(width: number, height: number): WindowSizeOrientation {
+  return width > height ? "landscape" : "portrait";
+}
+
+export function getWindowSizeBreakpointEntries<TBreakpoints extends WindowSizeBreakpoints>(
+  breakpoints: TBreakpoints,
+): Array<WindowSizeBreakpointEntry<TBreakpoints>> {
+  return (Object.entries(breakpoints) as Array<WindowSizeBreakpointEntry<TBreakpoints>>)
+    .filter(([, value]) => Number.isFinite(value))
+    .sort(([, previousValue], [, nextValue]) => previousValue - nextValue);
+}
+
+export function getWindowSizeBreakpointSignature(breakpoints: WindowSizeBreakpoints): string {
+  return JSON.stringify(Object.entries(breakpoints));
+}
+
+export function getWindowSizeBreakpoint<TBreakpoints extends WindowSizeBreakpoints>(
+  width: number,
+  breakpoints: TBreakpoints,
+): WindowSizeBreakpointKey<TBreakpoints> | null {
+  let activeBreakpoint: WindowSizeBreakpointKey<TBreakpoints> | null = null;
+
+  getWindowSizeBreakpointEntries(breakpoints).forEach(([key, value]) => {
+    if (width >= value) {
+      activeBreakpoint = key;
+    }
+  });
+
+  return activeBreakpoint;
+}
+
+function getBreakpointValue<TBreakpoints extends WindowSizeBreakpoints>(
+  breakpoints: TBreakpoints,
+  key: WindowSizeBreakpointKey<TBreakpoints>,
+): number | null {
+  const value = breakpoints[key];
+
+  return Number.isFinite(value) ? value : null;
+}
+
+function getNamedBreakpointValue(breakpoints: WindowSizeBreakpoints, key: string): number | null {
+  const value = breakpoints[key];
+
+  return Number.isFinite(value) ? value : null;
+}
+
+export function isAboveWindowSizeBreakpoint<TBreakpoints extends WindowSizeBreakpoints>(
+  width: number,
+  breakpoints: TBreakpoints,
+  key: WindowSizeBreakpointKey<TBreakpoints>,
+): boolean {
+  const value = getBreakpointValue(breakpoints, key);
+
+  return value === null ? false : width >= value;
+}
+
+export function isBelowWindowSizeBreakpoint<TBreakpoints extends WindowSizeBreakpoints>(
+  width: number,
+  breakpoints: TBreakpoints,
+  key: WindowSizeBreakpointKey<TBreakpoints>,
+): boolean {
+  const value = getBreakpointValue(breakpoints, key);
+
+  return value === null ? false : width < value;
+}
+
+export function isBetweenWindowSizeBreakpoints<TBreakpoints extends WindowSizeBreakpoints>(
+  width: number,
+  breakpoints: TBreakpoints,
+  min: WindowSizeBreakpointKey<TBreakpoints>,
+  max: WindowSizeBreakpointKey<TBreakpoints>,
+): boolean {
+  const minValue = getBreakpointValue(breakpoints, min);
+  const maxValue = getBreakpointValue(breakpoints, max);
+
+  return minValue === null || maxValue === null ? false : width >= minValue && width < maxValue;
+}
+
+export function getWindowSizeDeviceFlags(
+  width: number,
+  breakpoints: WindowSizeBreakpoints = DEFAULT_WINDOW_SIZE_BREAKPOINTS,
+): WindowSizeDeviceFlags {
+  const tabletMin =
+    getNamedBreakpointValue(breakpoints, "md") ??
+    getNamedBreakpointValue(breakpoints, "tablet") ??
+    DEFAULT_WINDOW_SIZE_BREAKPOINTS.md;
+  const desktopMin =
+    getNamedBreakpointValue(breakpoints, "lg") ??
+    getNamedBreakpointValue(breakpoints, "desktop") ??
+    DEFAULT_WINDOW_SIZE_BREAKPOINTS.lg;
+  const resolvedTabletMin = tabletMin < desktopMin ? tabletMin : DEFAULT_WINDOW_SIZE_BREAKPOINTS.md;
+  const resolvedDesktopMin =
+    tabletMin < desktopMin ? desktopMin : DEFAULT_WINDOW_SIZE_BREAKPOINTS.lg;
+
+  return {
+    isMobile: width < resolvedTabletMin,
+    isTablet: width >= resolvedTabletMin && width < resolvedDesktopMin,
+    isDesktop: width >= resolvedDesktopMin,
+  };
+}
+
+export function getWindowSizeRemountKey(
+  breakpoint: string | null,
+  orientation: WindowSizeOrientation,
+): string {
+  return `${breakpoint ?? "base"}:${orientation}`;
+}

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -1,2 +1,4 @@
+export type * from "../hooks/use-window-size/window-size.types";
+export * from "../hooks/use-window-size/window-size.utils";
 export * from "../misc/types";
 export * from "../utils";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
-    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx", "src/**/*.test.ts", "src/**/*.test.tsx"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov", "html"],


### PR DESCRIPTION
## Summary

## What does this PR change?

- Adds the new `useWindowSize` hook with SSR-safe viewport snapshots, shared resize subscriptions, breakpoint helpers, orientation flags, visual viewport support, debounce/throttle options, and tests.
- Documents `useWindowSize` with a docs page and live demo.
- Bumps the package version to `1.7.0`.
- Shows the current package version in the docs navbar.
- Enables Nextra copy controls for code blocks.
- Enables the Nextra Copy page / Open in ChatGPT / Open in Claude dropdown.
- Adds a CSS module declaration for global stylesheet imports in the docs app.

## Why is it needed?

- Consumers need a reliable viewport-size hook that works cleanly with React 18+, SSR, and App Router client boundaries.
- The docs need to expose the new hook with examples, return values, options, and usage guidance.
- The version bump reflects the new public API.
- Showing the package version in the navbar makes it easier for users to know which docs version they are reading.
- Copy buttons and AI page actions make the docs easier to reuse, share, and inspect.
- The CSS declaration prevents TypeScript side-effect import errors for `../styles/index.css` in stricter editor/compiler configurations.

## Checklist

- [x] Tests added/updated
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run test` passes
- [x] `npm run build` passes
- [x] Docs/README updated if API changed
