### PR TITLE
fix: harden RSC-critical hooks and package quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Validate package exports
+        run: npx publint

--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -9,7 +9,8 @@ typed reusable React hooks, small utility components, and clear client/server bo
 
 - [x] Rework `useFetch` into a production-safe primitive with abort support, configurable parsing, cache control, and better typing.
 - [x] Normalize naming and API consistency across hooks:
-      `useAsyncFnc` -> `useAsyncFn`, `immidate` -> `immediate`, and align `useGetScrollPosition` naming.
+      `useAsyncFnc` -> `useAsyncFn` (alias retained), `immidate` -> `immediate`, and align
+      `useGetScrollPosition` / `useWindowPosition` SSR safety.
 - [x] Review hooks that mutate inputs and decide whether they belong as React hooks or plain utilities, especially `useArray`.
 - [x] Expand test coverage across the existing public API before adding too many new exports.
 - [x] Tighten docs for client-only vs server-safe imports with examples for Next.js App Router and standard React apps.
@@ -42,7 +43,7 @@ typed reusable React hooks, small utility components, and clear client/server bo
 
 ## Phase 4: Headless Components and Utilities
 
-- [ ] `ClientOnly`
+- [x] `ClientOnly`
 - [ ] `Portal`
 - [ ] `VisuallyHidden`
 - [ ] `composeRefs`

--- a/PIPELINE.md
+++ b/PIPELINE.md
@@ -7,7 +7,8 @@ typed reusable React hooks, small utility components, and clear client/server bo
 
 ## Phase 1: Foundation
 
-- [x] Rework `useFetch` into a production-safe primitive with abort support, configurable parsing, cache control, and better typing.
+- [x] Rework `useFetch` into a production-safe primitive with abort support, configurable parsing,
+      cache control (header-aware keys, bounded cache), and better typing.
 - [x] Normalize naming and API consistency across hooks:
       `useAsyncFnc` -> `useAsyncFn` (alias retained), `immidate` -> `immediate`, and align
       `useGetScrollPosition` / `useWindowPosition` SSR safety.
@@ -54,7 +55,7 @@ typed reusable React hooks, small utility components, and clear client/server bo
 
 - [ ] Add `Changesets` for versioning and release notes.
 - [ ] Add `tsd` for public type tests.
-- [ ] Add `publint` and `arethetypeswrong` to package validation.
+- [x] Add `publint` to package validation (`arethetypeswrong` still open).
 - [ ] Add bundle size checks with `size-limit` or equivalent.
 - [ ] Add example apps for Next.js App Router and Vite.
 - [ ] Modernize the docs app dependencies and keep docs aligned with the published API.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,34 @@ export function ChartBoundary() {
 }
 ```
 
+### Async data (client-only)
+
+Prefer **`useFetch`** for HTTP reads and **`useMutation`** for writes / side effects. They expose status flags, abort, and typed results.
+
+`useAsync` / `useAsyncFn` remain for lightweight manual runners, but new code should use `useFetch` / `useMutation` when they fit.
+
+```tsx
+"use client";
+
+import { useFetch, useMutation } from "react-rsc-kit/client";
+
+export function Profile({ id }: { id: string }) {
+  const { data, loading, error } = useFetch<{ name: string }>(`/api/users/${id}`);
+  const save = useMutation(async (name: string) => {
+    await fetch(`/api/users/${id}`, { method: "PATCH", body: JSON.stringify({ name }) });
+  });
+
+  if (loading) return <p>Loading…</p>;
+  if (error || !data) return <p>Failed</p>;
+
+  return (
+    <button onClick={() => save.mutate(data.name)} disabled={save.isPending}>
+      {data.name}
+    </button>
+  );
+}
+```
+
 ## RSC Guidance
 
 - `react-rsc-kit` and `react-rsc-kit/server` are **server-safe** entrypoints.

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,3 @@
+# Forces npm/npx (used by some Cloudflare presets) to ignore optional peer conflicts
+# when resolving tooling. Prefer static `pnpm build` → `out` for this site.
+legacy-peer-deps=true

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,18 +43,20 @@ Those commands set `REACT_RSC_KIT_SOURCE=0` and use the installed package depend
 
 ### Cloudflare Pages (static export)
 
-This app uses Next.js `output: "export"`. Deploy it as a **static** Pages project — do **not** use `@cloudflare/next-on-pages` (that adapter targets SSR/Workers and currently fails with a wrangler / `workers-types` peer conflict under `npx`).
+This app uses Next.js `output: "export"`. Deploy it as a **static** Pages project — do **not** use
+`npx @cloudflare/next-on-pages@1` (deprecated adapter; wrong for static export; pulls Vercel’s builder).
 
-In the Cloudflare Pages project settings:
+In Cloudflare Pages → **Settings → Builds & deployments**:
 
 | Setting                | Value        |
 | ---------------------- | ------------ |
 | Root directory         | `docs`       |
+| Framework preset       | None         |
 | Build command          | `pnpm build` |
 | Build output directory | `out`        |
 | Node.js version        | `20` or `22` |
 
-After changing the build command, retry the deployment.
+After saving those settings, retry the deployment.
 
 ### Adding hook docs
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,21 @@ pnpm build:package
 
 Those commands set `REACT_RSC_KIT_SOURCE=0` and use the installed package dependency.
 
+### Cloudflare Pages (static export)
+
+This app uses Next.js `output: "export"`. Deploy it as a **static** Pages project — do **not** use `@cloudflare/next-on-pages` (that adapter targets SSR/Workers and currently fails with a wrangler / `workers-types` peer conflict under `npx`).
+
+In the Cloudflare Pages project settings:
+
+| Setting                | Value        |
+| ---------------------- | ------------ |
+| Root directory         | `docs`       |
+| Build command          | `pnpm build` |
+| Build output directory | `out`        |
+| Node.js version        | `20` or `22` |
+
+After changing the build command, retry the deployment.
+
 ### Adding hook docs
 
 For a new hook, add the MDX page under `docs/content/hooks`, add any live example under

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-rsc-kit",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",
@@ -28,6 +28,7 @@
         "jsdom": "^26.0.0",
         "lint-staged": "^15.5.0",
         "prettier": "^3.5.3",
+        "publint": "0.3.21",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "rimraf": "^6.0.1",
@@ -1377,6 +1378,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@publint/pack": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@publint/pack/-/pack-0.1.5.tgz",
+      "integrity": "sha512-edgyN2pP07uXiP4tJs0s8KVmU8M8i60YPbbI0/WDeok1mIJHRXz+CgD8I0nelwDkoCh3EWL/G5kGfbuHjsdbvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyexec": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -6097,6 +6114,16 @@
         "ufo": "^1.6.1"
       }
     },
+    "node_modules/mri": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+      "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6416,6 +6443,13 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.7.0.tgz",
+      "integrity": "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6729,6 +6763,28 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/publint": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/publint/-/publint-0.3.21.tgz",
+      "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@publint/pack": "^0.1.4",
+        "package-manager-detector": "^1.6.0",
+        "picocolors": "^1.1.1",
+        "sade": "^1.8.1"
+      },
+      "bin": {
+        "publint": "src/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://bjornlu.com/sponsor"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7063,6 +7119,19 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/sade": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mri": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/safe-array-concat": {
@@ -7888,9 +7957,9 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-rsc-kit",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "^19.8.0",

--- a/package.json
+++ b/package.json
@@ -141,6 +141,5 @@
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",
     "vitest": "^2.1.8"
-  },
-  "type": "commonjs"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,17 @@
   "description": "React hooks and utility components with RSC-safe server/client entrypoints.",
   "author": "react-rsc-kit contributors",
   "license": "MIT",
+  "keywords": [
+    "react",
+    "hooks",
+    "rsc",
+    "react-server-components",
+    "nextjs",
+    "typescript",
+    "client-only",
+    "ssr",
+    "utilities"
+  ],
   "homepage": "https://react-rsc-kit.puskaradhikari.com.np/",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -31,24 +31,44 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js"
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
     },
     "./client": {
-      "types": "./dist/client.d.ts",
-      "import": "./dist/client.mjs",
-      "require": "./dist/client.js"
+      "import": {
+        "types": "./dist/client.d.mts",
+        "default": "./dist/client.mjs"
+      },
+      "require": {
+        "types": "./dist/client.d.ts",
+        "default": "./dist/client.js"
+      }
     },
     "./server": {
-      "types": "./dist/server.d.ts",
-      "import": "./dist/server.mjs",
-      "require": "./dist/server.js"
+      "import": {
+        "types": "./dist/server.d.mts",
+        "default": "./dist/server.mjs"
+      },
+      "require": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
+      }
     },
     "./hooks": {
-      "types": "./dist/hooks.d.ts",
-      "import": "./dist/hooks.mjs",
-      "require": "./dist/hooks.js"
+      "import": {
+        "types": "./dist/hooks.d.mts",
+        "default": "./dist/hooks.mjs"
+      },
+      "require": {
+        "types": "./dist/hooks.d.ts",
+        "default": "./dist/hooks.js"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -78,7 +98,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "prepare": "husky",
-    "prepublishOnly": "npm run lint && npm run format:check && npm run typecheck && npm run test && npm run build"
+    "prepublishOnly": "npm run lint && npm run format:check && npm run typecheck && npm run test && npm run pack:check",
+    "pack:check": "npm run build && publint"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
@@ -113,11 +134,13 @@
     "jsdom": "^26.0.0",
     "lint-staged": "^15.5.0",
     "prettier": "^3.5.3",
+    "publint": "0.3.21",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "rimraf": "^6.0.1",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",
     "vitest": "^2.1.8"
-  }
+  },
+  "type": "commonjs"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rsc-kit",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "React hooks and utility components with RSC-safe server/client entrypoints.",
   "author": "react-rsc-kit contributors",
   "license": "MIT",

--- a/src/hooks/useAsync/useAsync.ts
+++ b/src/hooks/useAsync/useAsync.ts
@@ -1,37 +1,32 @@
 import { DependencyList, useEffect } from "react";
 
 import { AsyncFnReturn, FunctionReturningPromise } from "../../misc/types";
-import { useAsyncFnc } from "../useAsyncFnc";
+import { useAsyncFn } from "../useAsyncFnc";
 
 /**
- * It returns a hook for executing an asynchronous function with
- * optional immediate execution.
- * @param {T} fn - A function that returns a Promise. This function will be executed asynchronously.
- * @param {DependencyList} deps - The `deps` parameter is an optional array of dependencies that the
- * `fn` function depends on. It is used to determine when the `fn` function should be re-executed. If
- * any of the dependencies change, the `fn` function will be re-executed. If `deps` is
- * @param {boolean} [immidate=false] - The "immidate" parameter is a boolean flag that determines
- * whether the async function should be executed immediately upon component mount or not. If set to
- * true, the function will be executed immediately, otherwise it will only be executed when the
- * "execute" function is called.
- * @returns The `useAsync` function returns an array with two elements: the first element is an object
- * representing the current state of the asynchronous function (with properties such as `loading`,
- * `error`, and `data`), and the second element is a function that can be called to execute the
- * asynchronous function. The second element is typed as the same function passed in as the first
- * argument (`T`).
+ * Run an async function with tracked loading/error/value state.
+ *
+ * Pass `immediate: true` to execute on mount (and whenever `execute` identity changes).
+ * When `immediate` is false (default), state starts idle (`loading: false`) until `execute` is called.
+ *
+ * @param fn - Async function to track.
+ * @param deps - Dependency list passed through to the underlying callback.
+ * @param immediate - When true, execute on mount. Default false.
  */
 export function useAsync<T extends FunctionReturningPromise>(
   fn: T,
   deps: DependencyList = [],
-  immidate: boolean = false,
+  immediate: boolean = false,
 ): AsyncFnReturn<T> {
-  const [state, execute] = useAsyncFnc(fn, deps, {
-    loading: true,
+  const [state, execute] = useAsyncFn(fn, deps, {
+    loading: immediate,
   });
 
   useEffect(() => {
-    if (immidate) execute();
-  }, [execute, immidate]);
+    if (immediate) {
+      void execute();
+    }
+  }, [execute, immediate]);
 
   return [state, execute as T];
 }

--- a/src/hooks/useAsyncFnc/useAsyncFnc.ts
+++ b/src/hooks/useAsyncFnc/useAsyncFnc.ts
@@ -8,20 +8,15 @@ type StateFromFunctionReturningPromise<T extends FunctionReturningPromise> = Asy
 >;
 
 /**
- * It returns a state and a callback function for handling asynchronous
- * operations with automatic loading and error handling.
- * @param {T} fn - The asynchronous function that will be called when the returned callback is invoked.
- * @param {DependencyList} deps - `deps` is an optional array of dependencies that are passed to the
- * `useCallback` hook. These dependencies are used to determine when the `callback` function should be
- * re-created. If any of the dependencies change, the `callback` function will be re-created with the
- * new values. If `
- * @returns The function `useAsyncFn` returns an array containing two elements: the first element is an
- * object representing the current state of the asynchronous function, and the second element is the
- * callback function that can be used to trigger the asynchronous function. The state object contains
- * properties such as `loading`, `value`, and `error` to indicate the current status of the
- * asynchronous function. The callback function is a memo
+ * Manual async runner: returns `[state, execute]` without auto-invoking `fn`.
+ *
+ * Prefer `useMutation` or `useFetch` for new code when those APIs fit.
+ *
+ * @param fn - The asynchronous function invoked by `execute`.
+ * @param deps - Dependency list for the memoized `execute` callback.
+ * @param initialState - Initial async state (default `{ loading: false }`).
  */
-export function useAsyncFnc<T extends FunctionReturningPromise>(
+export function useAsyncFn<T extends FunctionReturningPromise>(
   fn: T,
   deps: DependencyList = [],
   initialState: StateFromFunctionReturningPromise<T> = { loading: false },
@@ -51,8 +46,14 @@ export function useAsyncFnc<T extends FunctionReturningPromise>(
         throw error;
       }
     },
+    // Caller-controlled dependency list (same pattern as useCallback(fn, deps)).
     deps,
   );
 
   return [state, execute as T];
 }
+
+/**
+ * @deprecated Use {@link useAsyncFn} instead. Kept for backward compatibility.
+ */
+export const useAsyncFnc = useAsyncFn;

--- a/src/hooks/useEventListener/useEventListener.ts
+++ b/src/hooks/useEventListener/useEventListener.ts
@@ -1,7 +1,8 @@
 import { RefObject } from "react";
 
 import { offEvent, onEvent } from "../../utils";
-import { useGetLatest, useIsomorphicEffect } from "../index";
+import { useGetLatest } from "../useGetLatest";
+import { useIsomorphicEffect } from "../useIsomorphicEffect";
 
 type ElementEventListener<K extends keyof HTMLElementEventMap> = (
   this: HTMLElement,
@@ -65,20 +66,27 @@ function resolveTarget(target: MaybeTargetRef): ListenerTarget | null {
 }
 
 /**
- * It tries to define a property on an object, and if it fails, it returns false. If it succeeds, it
- * returns true
+ * Detect whether the browser supports the options object form of addEventListener
+ * (including `passive` / `once` / `signal`) by observing a getter during attach.
  */
 const isOptionParamSupported = (): boolean => {
-  let optionSupported = false;
+  if (typeof window === "undefined" || typeof window.addEventListener !== "function") {
+    return false;
+  }
 
+  let optionSupported = false;
   try {
-    Object.defineProperty({}, "passive", {
-      get: () => {
+    const options = Object.defineProperty({}, "passive", {
+      get() {
         optionSupported = true;
-        return null;
+        return false;
       },
     });
-  } catch (_error) {
+
+    const noop = () => undefined;
+    window.addEventListener("test-passive-support", noop, options);
+    window.removeEventListener("test-passive-support", noop, options);
+  } catch {
     return false;
   }
 
@@ -86,11 +94,11 @@ const isOptionParamSupported = (): boolean => {
 };
 
 /**
- * A React hook that handles binding/unbinding event listeners in a smart way.
+ * Bind an event listener to a target (element, document, or window) and clean it up on change/unmount.
  *
  * @param config.target - The target to which the listener will be attached.
  * @param config.eventType - A case-sensitive string representing the event type to listen for.
- * @param config.handler - event listener callback.
+ * @param config.handler - Event listener callback.
  * @param shouldAttach - If set to false, the listener won't be attached. (default = true)
  */
 export const useEventListener: UseEventListener = (
@@ -118,11 +126,14 @@ export const useEventListener: UseEventListener = (
       (cachedHandler.current as (ev: Event) => void)(event);
     };
 
-    let thirdParam = cachedOptions.current;
+    let thirdParam: boolean | AddEventListenerOptions | undefined = cachedOptions.current;
 
-    if (typeof cachedOptions.current !== "boolean") {
-      if (isOptionParamSupported()) thirdParam = cachedOptions.current;
-      else thirdParam = cachedOptions.current?.capture;
+    if (typeof cachedOptions.current !== "boolean" && cachedOptions.current != null) {
+      if (isOptionParamSupported()) {
+        thirdParam = cachedOptions.current;
+      } else {
+        thirdParam = cachedOptions.current.capture;
+      }
     }
 
     if (shouldAttach) {

--- a/src/hooks/useEventListener/useEventListener.ts
+++ b/src/hooks/useEventListener/useEventListener.ts
@@ -68,8 +68,15 @@ function resolveTarget(target: MaybeTargetRef): ListenerTarget | null {
 /**
  * Detect whether the browser supports the options object form of addEventListener
  * (including `passive` / `once` / `signal`) by observing a getter during attach.
+ * Result is memoized after the first client-side probe.
  */
+let memoizedOptionSupported: boolean | undefined;
+
 const isOptionParamSupported = (): boolean => {
+  if (memoizedOptionSupported !== undefined) {
+    return memoizedOptionSupported;
+  }
+
   if (typeof window === "undefined" || typeof window.addEventListener !== "function") {
     return false;
   }
@@ -87,9 +94,11 @@ const isOptionParamSupported = (): boolean => {
     window.addEventListener("test-passive-support", noop, options);
     window.removeEventListener("test-passive-support", noop, options);
   } catch {
+    memoizedOptionSupported = false;
     return false;
   }
 
+  memoizedOptionSupported = optionSupported;
   return optionSupported;
 };
 

--- a/src/hooks/useFetch/useFetch.ts
+++ b/src/hooks/useFetch/useFetch.ts
@@ -234,9 +234,11 @@ function getRequestSignature(input: FetchInput, init?: RequestInit): string {
 function mergeSignals(
   controller: AbortController,
   requestSignal?: AbortSignal | null,
-): AbortSignal {
+): [AbortSignal, () => void] {
+  const noopCleanup = () => undefined;
+
   if (!requestSignal) {
-    return controller.signal;
+    return [controller.signal, noopCleanup];
   }
 
   const abortSignalWithAny = AbortSignal as typeof AbortSignal & {
@@ -244,7 +246,7 @@ function mergeSignals(
   };
 
   if (typeof abortSignalWithAny.any === "function") {
-    return abortSignalWithAny.any([controller.signal, requestSignal]);
+    return [abortSignalWithAny.any([controller.signal, requestSignal]), noopCleanup];
   }
 
   const forwardAbort = () => {
@@ -259,7 +261,12 @@ function mergeSignals(
     requestSignal.addEventListener("abort", forwardAbort, { once: true });
   }
 
-  return controller.signal;
+  return [
+    controller.signal,
+    () => {
+      requestSignal.removeEventListener("abort", forwardAbort);
+    },
+  ];
 }
 
 function getCachedValue<T>(cacheKey: string): CacheEntry<T> | null {
@@ -416,10 +423,12 @@ export function useFetch<T = unknown>(
         isFetching: true,
       }));
 
+      const [mergedSignal, cleanupSignal] = mergeSignals(controller, currentInit?.signal);
+
       try {
         const response = await fetch(currentInput, {
           ...currentInit,
-          signal: mergeSignals(controller, currentInit?.signal),
+          signal: mergedSignal,
         });
 
         if (!response.ok) {
@@ -482,6 +491,8 @@ export function useFetch<T = unknown>(
         }));
 
         return null;
+      } finally {
+        cleanupSignal();
       }
     },
     [cacheKey, cacheTime, keepPreviousData],

--- a/src/hooks/useFetch/useFetch.ts
+++ b/src/hooks/useFetch/useFetch.ts
@@ -48,6 +48,7 @@ interface CacheEntry<T> {
 }
 
 const responseCache = new Map<string, CacheEntry<unknown>>();
+const MAX_CACHE_ENTRIES = 100;
 
 export class UseFetchError<T = unknown> extends Error {
   readonly status: number;
@@ -140,8 +141,12 @@ function getCacheKey(
 
   const url =
     typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+  const headers = serializeHeaders(
+    init?.headers ?? (input instanceof Request ? input.headers : undefined),
+  );
+  const credentials = init?.credentials ?? (input instanceof Request ? input.credentials : "");
 
-  return `${method}:${url}`;
+  return `${method}:${url}:${headers}:${credentials}`;
 }
 
 function serializeHeaders(headers?: HeadersInit): string {
@@ -227,11 +232,11 @@ function getRequestSignature(input: FetchInput, init?: RequestInit): string {
 }
 
 function mergeSignals(
-  controllerSignal: AbortSignal,
+  controller: AbortController,
   requestSignal?: AbortSignal | null,
 ): AbortSignal {
   if (!requestSignal) {
-    return controllerSignal;
+    return controller.signal;
   }
 
   const abortSignalWithAny = AbortSignal as typeof AbortSignal & {
@@ -239,10 +244,22 @@ function mergeSignals(
   };
 
   if (typeof abortSignalWithAny.any === "function") {
-    return abortSignalWithAny.any([controllerSignal, requestSignal]);
+    return abortSignalWithAny.any([controller.signal, requestSignal]);
   }
 
-  return controllerSignal;
+  const forwardAbort = () => {
+    if (!controller.signal.aborted) {
+      controller.abort();
+    }
+  };
+
+  if (requestSignal.aborted) {
+    forwardAbort();
+  } else {
+    requestSignal.addEventListener("abort", forwardAbort, { once: true });
+  }
+
+  return controller.signal;
 }
 
 function getCachedValue<T>(cacheKey: string): CacheEntry<T> | null {
@@ -261,6 +278,15 @@ function getCachedValue<T>(cacheKey: string): CacheEntry<T> | null {
 }
 
 function setCachedValue<T>(cacheKey: string, data: T, statusCode: number, cacheTime: number) {
+  if (responseCache.has(cacheKey)) {
+    responseCache.delete(cacheKey);
+  } else if (responseCache.size >= MAX_CACHE_ENTRIES) {
+    const oldestKey = responseCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      responseCache.delete(oldestKey);
+    }
+  }
+
   responseCache.set(cacheKey, {
     data,
     statusCode,
@@ -393,7 +419,7 @@ export function useFetch<T = unknown>(
       try {
         const response = await fetch(currentInput, {
           ...currentInit,
-          signal: mergeSignals(controller.signal, currentInit?.signal),
+          signal: mergeSignals(controller, currentInit?.signal),
         });
 
         if (!response.ok) {
@@ -401,6 +427,7 @@ export function useFetch<T = unknown>(
           throw new UseFetchError(response, errorData);
         }
 
+        const responseForState = response.clone();
         const data = await parser(response);
 
         if (requestId !== requestIdRef.current || controller.signal.aborted) {
@@ -416,7 +443,7 @@ export function useFetch<T = unknown>(
         setState({
           data,
           error: null,
-          response,
+          response: responseForState,
           status: "success",
           statusCode: response.status,
           isFetching: false,

--- a/src/hooks/useGeolocation/useGeolocation.ts
+++ b/src/hooks/useGeolocation/useGeolocation.ts
@@ -85,8 +85,10 @@ export function useGeolocation(
   callback?: (coordinates: GeolocationCoordinates) => void,
   isEnabled = true,
 ): UseGeolocationResult {
-  // Default to a single mount request; opt into watch explicitly to avoid double GPS work.
-  const { enableHighAccuracy, maximumAge, timeout, watch = false, requestOnMount = true } = options;
+  // Default to a single mount request; when watch is enabled, skip getCurrentPosition.
+  const watch = options.watch ?? false;
+  const requestOnMount = options.requestOnMount ?? !watch;
+  const { enableHighAccuracy, maximumAge, timeout } = options;
 
   const supported = isGeolocationSupported();
   const shouldStartPending = isEnabled && supported && (watch || requestOnMount);

--- a/src/hooks/useGeolocation/useGeolocation.ts
+++ b/src/hooks/useGeolocation/useGeolocation.ts
@@ -85,7 +85,8 @@ export function useGeolocation(
   callback?: (coordinates: GeolocationCoordinates) => void,
   isEnabled = true,
 ): UseGeolocationResult {
-  const { enableHighAccuracy, maximumAge, timeout, watch = true, requestOnMount = true } = options;
+  // Default to a single mount request; opt into watch explicitly to avoid double GPS work.
+  const { enableHighAccuracy, maximumAge, timeout, watch = false, requestOnMount = true } = options;
 
   const supported = isGeolocationSupported();
   const shouldStartPending = isEnabled && supported && (watch || requestOnMount);

--- a/src/hooks/useGetLatest/useGetLatest.ts
+++ b/src/hooks/useGetLatest/useGetLatest.ts
@@ -1,17 +1,16 @@
 import { MutableRefObject, useRef } from "react";
 
-import { useIsomorphicEffect } from "../index";
+import { useIsomorphicEffect } from "../useIsomorphicEffect";
 
 /**
- * It is a React hook that stores & updates ref.current with the most recent value.
- * @param {T} value - T - The value you want to store in the ref.
- * @returns A ref object that is updated with the latest value of the value argument.
+ * Keep a ref synchronized with the latest value (useful inside stable callbacks/effects).
  */
 export const useGetLatest = <T>(value: T): MutableRefObject<T> => {
   const ref = useRef<T>(value);
 
   useIsomorphicEffect(() => {
-    void (ref.current = value);
+    ref.current = value;
   });
+
   return ref;
 };

--- a/src/hooks/useGetScrollPosition/useWindowScroll.ts
+++ b/src/hooks/useGetScrollPosition/useWindowScroll.ts
@@ -1,31 +1,46 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
-import { useEventListener } from "../index";
+import { useEventListener } from "../useEventListener";
+import { useIsomorphicEffect } from "../useIsomorphicEffect";
 
-/**
- * React hook to track window scroll position.
- * @param {Number} [initialPosition] - The initial scroll position.
- * @returns A number representing the current scroll position of the window.
- */
-
-interface IState {
+interface WindowPosition {
   x: number;
   y: number;
 }
 
-export const useWindowPosition = (): IState => {
-  const [scrollPosition, setScrollPosition] = useState<IState>({
-    x: 0,
-    y: 0,
-  });
+const INITIAL_POSITION: WindowPosition = { x: 0, y: 0 };
 
-  const updatePosition = () => {
-    setScrollPosition({ x: window.pageXOffset, y: window.pageYOffset });
+function readWindowPosition(): WindowPosition {
+  if (typeof window === "undefined") {
+    return INITIAL_POSITION;
+  }
+
+  return {
+    x: window.scrollX,
+    y: window.scrollY,
   };
+}
+
+/**
+ * Track the window scroll position in an SSR-safe way.
+ * Returns `{ x: 0, y: 0 }` until mounted, then syncs and listens for scroll events.
+ */
+export const useWindowPosition = (): WindowPosition => {
+  const [scrollPosition, setScrollPosition] = useState<WindowPosition>(INITIAL_POSITION);
+
+  const updatePosition = useCallback(() => {
+    setScrollPosition(readWindowPosition());
+  }, []);
+
+  useIsomorphicEffect(() => {
+    updatePosition();
+  }, [updatePosition]);
+
   useEventListener({
-    target: window,
+    target: typeof window !== "undefined" ? window : null,
     eventType: "scroll",
     handler: updatePosition,
+    options: { passive: true },
   });
 
   return scrollPosition;

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,4 +1,12 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 export type LocalStorageInitialValue<T> = T | (() => T);
 
@@ -15,6 +23,8 @@ interface StoredValueEnvelope {
   kind?: "undefined";
   value?: unknown;
 }
+
+const emptySubscribe = () => () => undefined;
 
 function resolveInitialValue<T>(initialValue: LocalStorageInitialValue<T>): T {
   return typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
@@ -126,7 +136,12 @@ function removeStoredValue(key: string): void {
 
 /**
  * Persist state in localStorage with JSON-safe serialization and reset helpers.
- * `remove`/`reset` use the latest `initialValue` for a given `key`; `setValue` skips storage when the value is unchanged (`Object.is`).
+ *
+ * Initializes from `initialValue` on the server and during hydration, then syncs from
+ * localStorage after mount to avoid hydration mismatches. `isSupported` is also SSR-safe.
+ *
+ * `remove`/`reset` use the latest `initialValue` for a given `key`; `setValue` skips storage
+ * when the value is unchanged (`Object.is`).
  */
 export function useLocalStorage<T>(
   key: string,
@@ -136,16 +151,37 @@ export function useLocalStorage<T>(
   const initialValueRef = useRef(initialValue);
   initialValueRef.current = initialValue;
 
-  const [value, setStoredValue] = useState<T>(() => readStoredValue(key, initialValue));
+  const [value, setStoredValue] = useState<T>(() => resolveInitialValue(initialValue));
+
+  const isSupported = useSyncExternalStore(
+    emptySubscribe,
+    () => getStorage() !== null,
+    () => false,
+  );
 
   useEffect(() => {
-    if (previousKeyRef.current === key) {
+    if (previousKeyRef.current !== key) {
+      previousKeyRef.current = key;
+      setStoredValue(readStoredValue(key, initialValueRef.current));
       return;
     }
 
-    previousKeyRef.current = key;
-    setStoredValue(readStoredValue(key, initialValue));
-  }, [initialValue, key]);
+    const storage = getStorage();
+    if (storage === null) {
+      return;
+    }
+
+    try {
+      const storedValue = storage.getItem(key);
+      if (storedValue === null) {
+        return;
+      }
+
+      setStoredValue(deserializeStoredValue(storedValue, initialValueRef.current));
+    } catch {
+      // Keep the hydrated initial value when storage reads fail.
+    }
+  }, [key]);
 
   const setValue = useCallback<Dispatch<SetStateAction<T>>>(
     (nextValue) => {
@@ -185,6 +221,6 @@ export function useLocalStorage<T>(
     setValue,
     remove,
     reset,
-    isSupported: getStorage() !== null,
+    isSupported,
   };
 }

--- a/src/hooks/useMounted/useMounted.ts
+++ b/src/hooks/useMounted/useMounted.ts
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useRef } from "react";
 
 /**
- * This function returns a boolean value indicating whether a component is currently mounted or not.
- * @returns A boolean value indicating whether the component is currently mounted or not.
+ * Returns a stable function that reports whether the component is still mounted.
+ * Prefer calling it (`isMounted()`) rather than treating the return value as a boolean.
  */
-export function useMounted() {
-  const isMounted = useRef<boolean>(false);
+export function useMounted(): () => boolean {
+  const isMounted = useRef(false);
 
-  const mouted = useCallback(() => isMounted.current, []);
+  const getIsMounted = useCallback(() => isMounted.current, []);
 
   useEffect(() => {
     isMounted.current = true;
@@ -16,5 +16,5 @@ export function useMounted() {
     };
   }, []);
 
-  return mouted;
+  return getIsMounted;
 }

--- a/src/hooks/useSessionStorage/useSessionStorage.ts
+++ b/src/hooks/useSessionStorage/useSessionStorage.ts
@@ -1,4 +1,12 @@
-import { Dispatch, SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 
 export type SessionStorageInitialValue<T> = T | (() => T);
 
@@ -15,6 +23,8 @@ interface StoredValueEnvelope {
   kind?: "undefined";
   value?: unknown;
 }
+
+const emptySubscribe = () => () => undefined;
 
 function resolveInitialValue<T>(initialValue: SessionStorageInitialValue<T>): T {
   return typeof initialValue === "function" ? (initialValue as () => T)() : initialValue;
@@ -126,7 +136,12 @@ function removeStoredValue(key: string): void {
 
 /**
  * Persist state in sessionStorage with JSON-safe serialization and reset helpers.
- * `remove`/`reset` use the latest `initialValue` for a given `key`; `setValue` skips storage when the value is unchanged (`Object.is`).
+ *
+ * Initializes from `initialValue` on the server and during hydration, then syncs from
+ * sessionStorage after mount to avoid hydration mismatches. `isSupported` is also SSR-safe.
+ *
+ * `remove`/`reset` use the latest `initialValue` for a given `key`; `setValue` skips storage
+ * when the value is unchanged (`Object.is`).
  */
 export function useSessionStorage<T>(
   key: string,
@@ -136,16 +151,37 @@ export function useSessionStorage<T>(
   const initialValueRef = useRef(initialValue);
   initialValueRef.current = initialValue;
 
-  const [value, setStoredValue] = useState<T>(() => readStoredValue(key, initialValue));
+  const [value, setStoredValue] = useState<T>(() => resolveInitialValue(initialValue));
+
+  const isSupported = useSyncExternalStore(
+    emptySubscribe,
+    () => getStorage() !== null,
+    () => false,
+  );
 
   useEffect(() => {
-    if (previousKeyRef.current === key) {
+    if (previousKeyRef.current !== key) {
+      previousKeyRef.current = key;
+      setStoredValue(readStoredValue(key, initialValueRef.current));
       return;
     }
 
-    previousKeyRef.current = key;
-    setStoredValue(readStoredValue(key, initialValue));
-  }, [initialValue, key]);
+    const storage = getStorage();
+    if (storage === null) {
+      return;
+    }
+
+    try {
+      const storedValue = storage.getItem(key);
+      if (storedValue === null) {
+        return;
+      }
+
+      setStoredValue(deserializeStoredValue(storedValue, initialValueRef.current));
+    } catch {
+      // Keep the hydrated initial value when storage reads fail.
+    }
+  }, [key]);
 
   const setValue = useCallback<Dispatch<SetStateAction<T>>>(
     (nextValue) => {
@@ -185,6 +221,6 @@ export function useSessionStorage<T>(
     setValue,
     remove,
     reset,
-    isSupported: getStorage() !== null,
+    isSupported,
   };
 }

--- a/tests/for.test.tsx
+++ b/tests/for.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { For } from "../src/server";
+
+describe("For", () => {
+  it("renders each item with index keys by default", () => {
+    render(<For each={["a", "b"]}>{(item) => <span>{item}</span>}</For>);
+
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+  });
+
+  it("uses getKey when provided", () => {
+    const { container } = render(
+      <For each={[{ id: "x" }, { id: "y" }]} getKey={(item) => item.id}>
+        {(item) => <span>{item.id}</span>}
+      </For>,
+    );
+
+    expect(container.textContent).toBe("xy");
+  });
+
+  it("renders empty state when the list is empty", () => {
+    render(
+      <For each={[]} empty={() => <span>none</span>}>
+        {(item) => <span>{item}</span>}
+      </For>,
+    );
+
+    expect(screen.getByText("none")).toBeInTheDocument();
+  });
+
+  it("renders loading state when isLoading is true", () => {
+    render(
+      <For each={["a"]} isLoading loading={() => <span>loading</span>}>
+        {(item) => <span>{item}</span>}
+      </For>,
+    );
+
+    expect(screen.getByText("loading")).toBeInTheDocument();
+    expect(screen.queryByText("a")).not.toBeInTheDocument();
+  });
+
+  it("wraps items when as is provided", () => {
+    const { container } = render(
+      <For each={["one"]} as="ul" wrapperProps={{ className: "list" }}>
+        {(item) => <li>{item}</li>}
+      </For>,
+    );
+
+    const list = container.querySelector("ul.list");
+    expect(list).not.toBeNull();
+    expect(list?.textContent).toBe("one");
+  });
+});

--- a/tests/storage.ssr.test.tsx
+++ b/tests/storage.ssr.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment node
+
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { useLocalStorage, useSessionStorage } from "../src/client/hooks";
+
+describe("storage SSR", () => {
+  it("renders useLocalStorage with the initial value and unsupported flag", () => {
+    function ServerStorage() {
+      const { value, isSupported } = useLocalStorage("ssr-local", "server-default");
+      return <span>{`${value}:${String(isSupported)}`}</span>;
+    }
+
+    expect(renderToString(<ServerStorage />)).toContain("<span>server-default:false</span>");
+  });
+
+  it("renders useSessionStorage with the initial value and unsupported flag", () => {
+    function ServerStorage() {
+      const { value, isSupported } = useSessionStorage("ssr-session", "session-default");
+      return <span>{`${value}:${String(isSupported)}`}</span>;
+    }
+
+    expect(renderToString(<ServerStorage />)).toContain("<span>session-default:false</span>");
+  });
+});

--- a/tests/use-async.test.tsx
+++ b/tests/use-async.test.tsx
@@ -1,0 +1,67 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useAsync, useAsyncFn } from "../src/client/hooks";
+
+describe("useAsyncFn", () => {
+  it("starts idle with loading false", () => {
+    const { result } = renderHook(() => useAsyncFn(async () => "ok"));
+
+    expect(result.current[0]).toEqual({ loading: false });
+  });
+
+  it("tracks success and error for manual execute", async () => {
+    const successFn = vi.fn(async (value: string) => value.toUpperCase());
+    const { result } = renderHook(() => useAsyncFn(successFn));
+
+    let resolved: string | undefined;
+
+    await act(async () => {
+      resolved = await result.current[1]("hello");
+    });
+
+    expect(resolved).toBe("HELLO");
+    expect(result.current[0]).toEqual({ loading: false, value: "HELLO" });
+    expect(successFn).toHaveBeenCalledWith("hello");
+
+    const failingFn = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const failing = renderHook(() => useAsyncFn(failingFn));
+
+    await act(async () => {
+      await expect(failing.result.current[1]()).rejects.toThrow("boom");
+    });
+
+    expect(failing.result.current[0].loading).toBe(false);
+    expect(failing.result.current[0].error).toEqual(new Error("boom"));
+  });
+});
+
+describe("useAsync", () => {
+  it("stays idle when immediate is false", async () => {
+    const fn = vi.fn(async () => "value");
+    const { result } = renderHook(() => useAsync(fn, [], false));
+
+    expect(result.current[0]).toEqual({ loading: false });
+    expect(fn).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current[1]();
+    });
+
+    expect(result.current[0]).toEqual({ loading: false, value: "value" });
+  });
+
+  it("executes on mount when immediate is true", async () => {
+    const fn = vi.fn(async () => "immediate");
+    const { result } = renderHook(() => useAsync(fn, [], true));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toEqual({ loading: false, value: "immediate" });
+  });
+});

--- a/tests/use-event-listener.test.tsx
+++ b/tests/use-event-listener.test.tsx
@@ -1,0 +1,98 @@
+import { act, renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useEventListener } from "../src/client/hooks";
+
+describe("useEventListener", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("attaches and detaches a window listener", () => {
+    const handler = vi.fn();
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+
+    const { unmount } = renderHook(() =>
+      useEventListener({
+        target: window,
+        eventType: "resize",
+        handler,
+      }),
+    );
+
+    expect(addSpy).toHaveBeenCalledWith("resize", expect.any(Function), undefined);
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function), undefined);
+  });
+
+  it("passes passive options through when supported", () => {
+    const handler = vi.fn();
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    renderHook(() =>
+      useEventListener({
+        target: window,
+        eventType: "scroll",
+        handler,
+        options: { passive: true, capture: false },
+      }),
+    );
+
+    const scrollCall = addSpy.mock.calls.find((call) => call[0] === "scroll");
+    expect(scrollCall?.[2]).toEqual({ passive: true, capture: false });
+  });
+
+  it("binds to an element ref target", () => {
+    const handler = vi.fn();
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    const { unmount } = renderHook(() => {
+      const ref = useRef<HTMLButtonElement | null>(button);
+      useEventListener({
+        target: ref,
+        eventType: "click",
+        handler,
+      });
+    });
+
+    act(() => {
+      button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    unmount();
+    button.remove();
+  });
+
+  it("does not attach when shouldAttach is false", () => {
+    const handler = vi.fn();
+    const addSpy = vi.spyOn(window, "addEventListener");
+    addSpy.mockClear();
+
+    renderHook(() =>
+      useEventListener(
+        {
+          target: window,
+          eventType: "keydown",
+          handler,
+        },
+        false,
+      ),
+    );
+
+    const keydownCalls = addSpy.mock.calls.filter((call) => call[0] === "keydown");
+    expect(keydownCalls).toHaveLength(0);
+  });
+});

--- a/tests/use-fetch.test.tsx
+++ b/tests/use-fetch.test.tsx
@@ -207,4 +207,79 @@ describe("useFetch", () => {
     expect(globalThis.fetch).toHaveBeenCalledTimes(2);
     expect(result.current.data).toEqual({ id: 2 });
   });
+
+  it("keys cache entries by headers and keeps response body readable", async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(jsonResponse({ id: "a" }))
+      .mockResolvedValueOnce(jsonResponse({ id: "b" }));
+
+    const first = renderHook(() =>
+      useFetch<{ id: string }>(
+        "/auth",
+        { headers: { Authorization: "Bearer one" } },
+        { cacheTime: 60_000 },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(first.result.current.data).toEqual({ id: "a" });
+    });
+
+    await expect(first.result.current.response?.json()).resolves.toEqual({ id: "a" });
+
+    first.unmount();
+
+    const second = renderHook(() =>
+      useFetch<{ id: string }>(
+        "/auth",
+        { headers: { Authorization: "Bearer two" } },
+        { cacheTime: 60_000 },
+      ),
+    );
+
+    await waitFor(() => {
+      expect(second.result.current.data).toEqual({ id: "b" });
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("aborts when the caller-provided signal is aborted", async () => {
+    const controller = new AbortController();
+    let seenSignal: AbortSignal | undefined;
+
+    vi.mocked(globalThis.fetch).mockImplementationOnce(async (_input, init) => {
+      seenSignal = init?.signal as AbortSignal | undefined;
+
+      return await new Promise<Response>((_resolve, reject) => {
+        const abortError = () => reject(new DOMException("Aborted", "AbortError"));
+
+        if (seenSignal?.aborted) {
+          abortError();
+          return;
+        }
+
+        seenSignal?.addEventListener("abort", abortError, { once: true });
+      });
+    });
+
+    const { result } = renderHook(() =>
+      useFetch("/abortable", {
+        signal: controller.signal,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(seenSignal).toBeDefined();
+    });
+
+    await act(async () => {
+      controller.abort();
+    });
+
+    await waitFor(() => {
+      expect(seenSignal?.aborted).toBe(true);
+      expect(result.current.isFetching).toBe(false);
+    });
+  });
 });

--- a/tests/use-geolocation.test.tsx
+++ b/tests/use-geolocation.test.tsx
@@ -110,14 +110,14 @@ describe("useGeolocation", () => {
     });
   });
 
-  it("requests current position and starts watching by default", async () => {
+  it("requests current position on mount without watching by default", async () => {
     const callback = vi.fn();
     const { result } = renderHook(() => useGeolocation({}, callback));
 
     expect(geolocation.getCurrentPosition).toHaveBeenCalledTimes(1);
-    expect(geolocation.watchPosition).toHaveBeenCalledTimes(1);
+    expect(geolocation.watchPosition).not.toHaveBeenCalled();
     expect(result.current.loading).toBe(true);
-    expect(result.current.isWatching).toBe(true);
+    expect(result.current.isWatching).toBe(false);
 
     act(() => {
       geolocation.emitCurrent(
@@ -178,7 +178,7 @@ describe("useGeolocation", () => {
   });
 
   it("clears the active watch via cancel", () => {
-    const { result } = renderHook(() => useGeolocation());
+    const { result } = renderHook(() => useGeolocation({ watch: true }));
 
     expect(result.current.isWatching).toBe(true);
 

--- a/tests/use-geolocation.test.tsx
+++ b/tests/use-geolocation.test.tsx
@@ -180,6 +180,8 @@ describe("useGeolocation", () => {
   it("clears the active watch via cancel", () => {
     const { result } = renderHook(() => useGeolocation({ watch: true }));
 
+    expect(geolocation.watchPosition).toHaveBeenCalledTimes(1);
+    expect(geolocation.getCurrentPosition).not.toHaveBeenCalled();
     expect(result.current.isWatching).toBe(true);
 
     act(() => {

--- a/tests/use-utility-hooks.test.tsx
+++ b/tests/use-utility-hooks.test.tsx
@@ -1,0 +1,37 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useGetLatest, useIsomorphicEffect, useMounted } from "../src/client/hooks";
+
+describe("useMounted", () => {
+  it("returns a function that is true while mounted and false after unmount", () => {
+    const { result, unmount } = renderHook(() => useMounted());
+
+    expect(typeof result.current).toBe("function");
+    expect(result.current()).toBe(true);
+
+    unmount();
+
+    expect(result.current()).toBe(false);
+  });
+});
+
+describe("useGetLatest", () => {
+  it("keeps a ref pointing at the latest value", () => {
+    const { result, rerender } = renderHook(({ value }) => useGetLatest(value), {
+      initialProps: { value: "a" },
+    });
+
+    expect(result.current.current).toBe("a");
+
+    rerender({ value: "b" });
+
+    expect(result.current.current).toBe("b");
+  });
+});
+
+describe("useIsomorphicEffect", () => {
+  it("is a function suitable for isomorphic effect usage", () => {
+    expect(typeof useIsomorphicEffect).toBe("function");
+  });
+});

--- a/tests/use-window-position.ssr.test.tsx
+++ b/tests/use-window-position.ssr.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment node
+
+import { renderToString } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { useWindowPosition } from "../src/client/hooks";
+
+describe("useWindowPosition SSR", () => {
+  it("renders without accessing window", () => {
+    function ServerScroll() {
+      const { x, y } = useWindowPosition();
+      return <span>{`${x},${y}`}</span>;
+    }
+
+    expect(() => renderToString(<ServerScroll />)).not.toThrow();
+    expect(renderToString(<ServerScroll />)).toContain("<span>0,0</span>");
+  });
+});

--- a/tests/use-window-position.test.tsx
+++ b/tests/use-window-position.test.tsx
@@ -1,0 +1,47 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useWindowPosition } from "../src/client/hooks";
+
+describe("useWindowPosition", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "scrollX", { configurable: true, value: 0, writable: true });
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 0, writable: true });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reads the current scroll position after mount", () => {
+    Object.defineProperty(window, "scrollX", { configurable: true, value: 24, writable: true });
+    Object.defineProperty(window, "scrollY", { configurable: true, value: 48, writable: true });
+
+    const { result } = renderHook(() => useWindowPosition());
+
+    expect(result.current).toEqual({ x: 24, y: 48 });
+  });
+
+  it("updates when the window scrolls", () => {
+    const { result } = renderHook(() => useWindowPosition());
+
+    expect(result.current).toEqual({ x: 0, y: 0 });
+
+    act(() => {
+      Object.defineProperty(window, "scrollX", { configurable: true, value: 10, writable: true });
+      Object.defineProperty(window, "scrollY", { configurable: true, value: 20, writable: true });
+      window.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current).toEqual({ x: 10, y: 20 });
+  });
+
+  it("registers a passive scroll listener", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+
+    renderHook(() => useWindowPosition());
+
+    const scrollCall = addSpy.mock.calls.find((call) => call[0] === "scroll");
+    expect(scrollCall?.[2]).toEqual({ passive: true });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,12 @@ export default defineConfig({
       reportsDirectory: "./coverage",
       include: ["src/**/*.{ts,tsx}"],
       exclude: ["src/**/*.demo.ts", "src/**/*.demo.tsx"],
+      thresholds: {
+        lines: 70,
+        functions: 70,
+        branches: 60,
+        statements: 70,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Fix P0 SSR/hydration and correctness bugs (`useAsync`, storage, `useEventListener`, `useWindowPosition`).
- Harden `useFetch` (header-aware cache, AbortSignal forwarding, Response cloning) and make geolocation watch opt-in.
- Add missing tests, async API guidance, npm keywords, coverage thresholds, and `publint` validation with dual ESM/CJS export types.
- Bump version to **1.9.0** for release on merge.

## Test plan
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run pack:check`
- [ ] Smoke-check Next.js App Router hydration for storage + `ClientOnly` + `/client` imports